### PR TITLE
feat: Register 화면 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -38,9 +38,11 @@
         <entry key="app/src/main/res/drawable/ic_player_stop.xml" value="0.1075" />
         <entry key="app/src/main/res/drawable/ic_plus.xml" value="0.2625" />
         <entry key="app/src/main/res/drawable/ic_profile.xml" value="0.1875" />
+        <entry key="app/src/main/res/layout/activity_album_register.xml" value="0.2890625" />
         <entry key="app/src/main/res/layout/activity_home.xml" value="0.258514404296875" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.5873618080977994" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.504601226993865" />
+        <entry key="app/src/main/res/layout/activity_musci_register.xml" value="0.2890625" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_album.xml" value="0.2524271844660194" />
         <entry key="app/src/main/res/layout/fragment_first.xml" value="0.2671875" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,7 +39,7 @@
         <entry key="app/src/main/res/drawable/ic_player_stop.xml" value="0.1075" />
         <entry key="app/src/main/res/drawable/ic_plus.xml" value="0.2625" />
         <entry key="app/src/main/res/drawable/ic_profile.xml" value="0.1875" />
-        <entry key="app/src/main/res/layout/activity_album_register.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/activity_album_register.xml" value="0.4218181818181818" />
         <entry key="app/src/main/res/layout/activity_home.xml" value="0.258514404296875" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.5873618080977994" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.504601226993865" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,7 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="../../../../../layout/custom_preview.xml" value="0.22135416666666666" />
+        <entry key="../../../.gradle/caches/transforms-3/5a98fff26bc2354bec39a8eb44ac20a5/transformed/circleindicator-2.1.6/res/drawable/white_radius.xml" value="0.293" />
         <entry key="../../../.gradle/caches/transforms-3/93b89c6e488660ce77e39a6c51b0754b/transformed/play-services-base-18.0.1/res/drawable/common_google_signin_btn_icon_dark.xml" value="0.216" />
         <entry key="app/src/main/res/drawable-v24/bg_login_imgae.xml" value="0.225" />
         <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.203" />
@@ -38,11 +39,12 @@
         <entry key="app/src/main/res/drawable/ic_player_stop.xml" value="0.1075" />
         <entry key="app/src/main/res/drawable/ic_plus.xml" value="0.2625" />
         <entry key="app/src/main/res/drawable/ic_profile.xml" value="0.1875" />
-        <entry key="app/src/main/res/layout/activity_album_register.xml" value="0.2890625" />
+        <entry key="app/src/main/res/layout/activity_album_register.xml" value="0.1" />
         <entry key="app/src/main/res/layout/activity_home.xml" value="0.258514404296875" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.5873618080977994" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.504601226993865" />
         <entry key="app/src/main/res/layout/activity_musci_register.xml" value="0.2890625" />
+        <entry key="app/src/main/res/layout/activity_music_register.xml" value="0.2890625" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_album.xml" value="0.2524271844660194" />
         <entry key="app/src/main/res/layout/fragment_first.xml" value="0.2671875" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,6 +14,8 @@
         <entry key="app/src/main/res/drawable/bg_bottom_left_round.xml" value="0.2625" />
         <entry key="app/src/main/res/drawable/bg_bottom_navigation_item.xml" value="0.2625" />
         <entry key="app/src/main/res/drawable/bg_bottom_right_round.xml" value="0.2625" />
+        <entry key="app/src/main/res/drawable/bg_btn_selector.xml" value="0.293" />
+        <entry key="app/src/main/res/drawable/bg_login_image.xml" value="0.293" />
         <entry key="app/src/main/res/drawable/bg_login_imgae.xml" value="0.1275" />
         <entry key="app/src/main/res/drawable/dot_selected.xml" value="0.1535" />
         <entry key="app/src/main/res/drawable/dot_selected_white.xml" value="0.2625" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -45,7 +45,7 @@
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.5873618080977994" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.504601226993865" />
         <entry key="app/src/main/res/layout/activity_musci_register.xml" value="0.2890625" />
-        <entry key="app/src/main/res/layout/activity_music_register.xml" value="0.2890625" />
+        <entry key="app/src/main/res/layout/activity_music_register.xml" value="0.39347991943359384" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_ai_album_select.xml" value="0.21666666666666667" />
         <entry key="app/src/main/res/layout/fragment_album.xml" value="0.2524271844660194" />
@@ -55,13 +55,14 @@
         <entry key="app/src/main/res/layout/fragment_like_music.xml" value="0.2913518269856771" />
         <entry key="app/src/main/res/layout/fragment_music.xml" value="0.2022932022932023" />
         <entry key="app/src/main/res/layout/fragment_music_player.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/fragment_music_upload.xml" value="0.21666666666666667" />
+        <entry key="app/src/main/res/layout/fragment_music_upload.xml" value="0.36252543131510423" />
         <entry key="app/src/main/res/layout/fragment_my_art.xml" value="0.16666666666666666" />
         <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.17916666666666667" />
         <entry key="app/src/main/res/layout/fragment_second.xml" value="0.2671875" />
         <entry key="app/src/main/res/layout/fragment_setting.xml" value="0.19270833333333334" />
         <entry key="app/src/main/res/layout/fragment_user_info.xml" value="0.30121951219512194" />
         <entry key="app/src/main/res/layout/fragment_user_info_editor.xml" value="0.28014842300556586" />
+        <entry key="app/src/main/res/layout/item_ai_image.xml" value="0.2890625" />
         <entry key="app/src/main/res/layout/item_album.xml" value="0.2345679012345679" />
         <entry key="app/src/main/res/layout/item_chart_music.xml" value="0.4107485604606526" />
         <entry key="app/src/main/res/layout/item_new_music.xml" value="0.3609375" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -23,6 +23,8 @@
         <entry key="app/src/main/res/drawable/ic_album.xml" value="0.1875" />
         <entry key="app/src/main/res/drawable/ic_camera.xml" value="0.254" />
         <entry key="app/src/main/res/drawable/ic_down_arrow.xml" value="0.279" />
+        <entry key="app/src/main/res/drawable/ic_fast_forward.xml" value="0.254" />
+        <entry key="app/src/main/res/drawable/ic_fast_rewind.xml" value="0.254" />
         <entry key="app/src/main/res/drawable/ic_home.xml" value="0.1875" />
         <entry key="app/src/main/res/drawable/ic_left_arrow.xml" value="0.2625" />
         <entry key="app/src/main/res/drawable/ic_like.xml" value="0.1875" />
@@ -47,7 +49,7 @@
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.5873618080977994" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.504601226993865" />
         <entry key="app/src/main/res/layout/activity_musci_register.xml" value="0.2890625" />
-        <entry key="app/src/main/res/layout/activity_music_register.xml" value="0.39347991943359384" />
+        <entry key="app/src/main/res/layout/activity_music_register.xml" value="0.2507934570312501" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_ai_album_select.xml" value="0.21666666666666667" />
         <entry key="app/src/main/res/layout/fragment_album.xml" value="0.2524271844660194" />
@@ -56,7 +58,7 @@
         <entry key="app/src/main/res/layout/fragment_like_album.xml" value="0.28229166666666666" />
         <entry key="app/src/main/res/layout/fragment_like_music.xml" value="0.2913518269856771" />
         <entry key="app/src/main/res/layout/fragment_music.xml" value="0.2022932022932023" />
-        <entry key="app/src/main/res/layout/fragment_music_player.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_music_player.xml" value="0.4672653198242188" />
         <entry key="app/src/main/res/layout/fragment_music_upload.xml" value="0.36252543131510423" />
         <entry key="app/src/main/res/layout/fragment_my_art.xml" value="0.16666666666666666" />
         <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.17916666666666667" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,6 +6,7 @@
         <entry key="../../../../../layout/custom_preview.xml" value="0.22135416666666666" />
         <entry key="../../../.gradle/caches/transforms-3/5a98fff26bc2354bec39a8eb44ac20a5/transformed/circleindicator-2.1.6/res/drawable/white_radius.xml" value="0.293" />
         <entry key="../../../.gradle/caches/transforms-3/93b89c6e488660ce77e39a6c51b0754b/transformed/play-services-base-18.0.1/res/drawable/common_google_signin_btn_icon_dark.xml" value="0.216" />
+        <entry key="../../../Library/Android/sdk/platforms/android-32/data/res/layout/simple_spinner_dropdown_item.xml" value="0.18125" />
         <entry key="app/src/main/res/drawable-v24/bg_login_imgae.xml" value="0.225" />
         <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.203" />
         <entry key="app/src/main/res/drawable-v24/ic_logo_combine.xml" value="0.225" />
@@ -46,6 +47,7 @@
         <entry key="app/src/main/res/layout/activity_musci_register.xml" value="0.2890625" />
         <entry key="app/src/main/res/layout/activity_music_register.xml" value="0.2890625" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_ai_album_select.xml" value="0.21666666666666667" />
         <entry key="app/src/main/res/layout/fragment_album.xml" value="0.2524271844660194" />
         <entry key="app/src/main/res/layout/fragment_first.xml" value="0.2671875" />
         <entry key="app/src/main/res/layout/fragment_like.xml" value="0.318448883666275" />
@@ -53,6 +55,7 @@
         <entry key="app/src/main/res/layout/fragment_like_music.xml" value="0.2913518269856771" />
         <entry key="app/src/main/res/layout/fragment_music.xml" value="0.2022932022932023" />
         <entry key="app/src/main/res/layout/fragment_music_player.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_music_upload.xml" value="0.21666666666666667" />
         <entry key="app/src/main/res/layout/fragment_my_art.xml" value="0.16666666666666666" />
         <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.17916666666666667" />
         <entry key="app/src/main/res/layout/fragment_second.xml" value="0.2671875" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,18 @@
             android:exported="false"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity" />
+
+        <activity
+            android:name=".presentation.register.album.AlbumRegisterActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" />
+
+        <activity
+            android:name=".presentation.register.music.MusicRegisterActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/mood/MoodDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/mood/MoodDataSource.kt
@@ -1,0 +1,3 @@
+package com.capstone.artwhale.data.datasource.mood
+
+interface MoodDataSource {}

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/mood/MoodDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/mood/MoodDataSourceImpl.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.data.datasource.mood
+
+import com.capstone.artwhale.data.service.MoodService
+import javax.inject.Inject
+
+class MoodDataSourceImpl @Inject constructor(
+    private val moodService: MoodService
+) : MoodDataSource {}

--- a/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
@@ -148,4 +148,18 @@ class AlbumRepositoryImpl @Inject constructor(
             ),
         )
     }
+
+    override suspend fun getAiAlbumImageList(): List<String> {
+        return listOf(
+            "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
+        )
+    }
 }

--- a/app/src/main/java/com/capstone/artwhale/data/repository/MoodRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/MoodRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.capstone.artwhale.data.repository
+
+import com.capstone.artwhale.data.datasource.mood.MoodDataSource
+import com.capstone.artwhale.domain.model.Mood
+import com.capstone.artwhale.domain.repository.MoodRepository
+import javax.inject.Inject
+
+class MoodRepositoryImpl @Inject constructor(
+    private val moodDataSource: MoodDataSource
+) : MoodRepository {
+
+    override suspend fun getMoodList(): List<Mood> {
+        return listOf(
+            Mood(0, "Happy"),
+            Mood(1, "Sad"),
+            Mood(2, "Bad"),
+        )
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/data/service/MoodService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/MoodService.kt
@@ -1,0 +1,3 @@
+package com.capstone.artwhale.data.service
+
+interface MoodService {}

--- a/app/src/main/java/com/capstone/artwhale/di/DataSourceModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/DataSourceModule.kt
@@ -4,10 +4,14 @@ import com.capstone.artwhale.data.datasource.album.AlbumDataSource
 import com.capstone.artwhale.data.datasource.album.AlbumDataSourceImpl
 import com.capstone.artwhale.data.datasource.auth.AuthDataSource
 import com.capstone.artwhale.data.datasource.auth.AuthDataSourceImpl
+import com.capstone.artwhale.data.datasource.mood.MoodDataSource
+import com.capstone.artwhale.data.datasource.mood.MoodDataSourceImpl
 import com.capstone.artwhale.data.datasource.music.MusicDataSource
 import com.capstone.artwhale.data.datasource.music.MusicDataSourceImpl
 import com.capstone.artwhale.data.datasource.notice.NoticeDataSource
 import com.capstone.artwhale.data.datasource.notice.NoticeDataSourceImpl
+import com.capstone.artwhale.data.repository.MoodRepositoryImpl
+import com.capstone.artwhale.domain.repository.MoodRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -41,4 +45,10 @@ abstract class DataSourceModule {
     abstract fun provideAlbumDataSource(
         albumDataSource: AlbumDataSourceImpl
     ): AlbumDataSource
+
+    @Singleton
+    @Binds
+    abstract fun provideMoodDataSource(
+        moodDataSource: MoodDataSourceImpl
+    ): MoodDataSource
 }

--- a/app/src/main/java/com/capstone/artwhale/di/NetworkModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/NetworkModule.kt
@@ -2,10 +2,7 @@ package com.capstone.artwhale.di
 
 import com.capstone.artwhale.BuildConfig
 import com.capstone.artwhale.BuildConfig.BASE_URL
-import com.capstone.artwhale.data.service.AlbumService
-import com.capstone.artwhale.data.service.AuthService
-import com.capstone.artwhale.data.service.MusicService
-import com.capstone.artwhale.data.service.NoticeService
+import com.capstone.artwhale.data.service.*
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -80,5 +77,11 @@ object NetworkModule {
     @Provides
     fun provideAlbumService(retrofit: Retrofit): AlbumService {
         return retrofit.create(AlbumService::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideMoodService(retrofit: Retrofit): MoodService {
+        return retrofit.create(MoodService::class.java)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/di/RepositoryModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/RepositoryModule.kt
@@ -1,13 +1,7 @@
 package com.capstone.artwhale.di
 
-import com.capstone.artwhale.data.repository.AlbumRepositoryImpl
-import com.capstone.artwhale.data.repository.AuthRepositoryImpl
-import com.capstone.artwhale.data.repository.MusicRepositoryImpl
-import com.capstone.artwhale.data.repository.NoticeRepositoryImpl
-import com.capstone.artwhale.domain.repository.AlbumRepository
-import com.capstone.artwhale.domain.repository.AuthRepository
-import com.capstone.artwhale.domain.repository.MusicRepository
-import com.capstone.artwhale.domain.repository.NoticeRepository
+import com.capstone.artwhale.data.repository.*
+import com.capstone.artwhale.domain.repository.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -41,4 +35,10 @@ abstract class RepositoryModule {
     abstract fun provideAlbumRepository(
         albumRepository: AlbumRepositoryImpl
     ): AlbumRepository
+
+    @Singleton
+    @Binds
+    abstract fun provideMoodRepository(
+        moodRepository: MoodRepositoryImpl
+    ): MoodRepository
 }

--- a/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
@@ -12,6 +12,8 @@ import com.capstone.artwhale.domain.usecase.auth.GetMyInfoUseCase
 import com.capstone.artwhale.domain.usecase.auth.LoginUseCase
 import com.capstone.artwhale.domain.usecase.auth.impl.GetMyInfoUseCaseImpl
 import com.capstone.artwhale.domain.usecase.auth.impl.LoginUseCaseImpl
+import com.capstone.artwhale.domain.usecase.mood.GetMoodListUseCase
+import com.capstone.artwhale.domain.usecase.mood.impl.GetMoodListUseCaseImpl
 import com.capstone.artwhale.domain.usecase.music.GetLikeMusicListUseCase
 import com.capstone.artwhale.domain.usecase.music.GetMusicChartUseCase
 import com.capstone.artwhale.domain.usecase.music.GetMyMusicListUseCase
@@ -97,4 +99,10 @@ abstract class UseCaseModule {
     abstract fun provideGetMyInfoUseCase(
         getMyInfoUseCase: GetMyInfoUseCaseImpl
     ): GetMyInfoUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideGetMoodListUseCase(
+        getMoodListUseCase: GetMoodListUseCaseImpl
+    ): GetMoodListUseCase
 }

--- a/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
@@ -1,13 +1,7 @@
 package com.capstone.artwhale.di
 
-import com.capstone.artwhale.domain.usecase.album.GetAlbumRankingUseCase
-import com.capstone.artwhale.domain.usecase.album.GetAllAlbumUseCase
-import com.capstone.artwhale.domain.usecase.album.GetLikeAlbumListUseCase
-import com.capstone.artwhale.domain.usecase.album.GetMyAlbumListUseCase
-import com.capstone.artwhale.domain.usecase.album.impl.GetAlbumRankingUseCaseImpl
-import com.capstone.artwhale.domain.usecase.album.impl.GetAllAlbumUseCaseImpl
-import com.capstone.artwhale.domain.usecase.album.impl.GetLikeAlbumListUseCaseImpl
-import com.capstone.artwhale.domain.usecase.album.impl.GetMyAlbumListUseCaseImpl
+import com.capstone.artwhale.domain.usecase.album.*
+import com.capstone.artwhale.domain.usecase.album.impl.*
 import com.capstone.artwhale.domain.usecase.auth.GetMyInfoUseCase
 import com.capstone.artwhale.domain.usecase.auth.LoginUseCase
 import com.capstone.artwhale.domain.usecase.auth.impl.GetMyInfoUseCaseImpl
@@ -105,4 +99,10 @@ abstract class UseCaseModule {
     abstract fun provideGetMoodListUseCase(
         getMoodListUseCase: GetMoodListUseCaseImpl
     ): GetMoodListUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideGetAiAlbumImageListUseCase(
+        getAiAlbumImageListUseCase: GetAiAlbumImageListUseCaseImpl
+    ): GetAiAlbumImageListUseCase
 }

--- a/app/src/main/java/com/capstone/artwhale/domain/model/Mood.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/model/Mood.kt
@@ -1,0 +1,6 @@
+package com.capstone.artwhale.domain.model
+
+data class Mood(
+    val id: Int,
+    val name: String,
+)

--- a/app/src/main/java/com/capstone/artwhale/domain/repository/AlbumRepository.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/repository/AlbumRepository.kt
@@ -8,4 +8,5 @@ interface AlbumRepository {
     suspend fun getAllAlbum(): List<Album>
     suspend fun getMyAlbumList(): List<Album>
     suspend fun getLikeAlbumList(): List<Album>
+    suspend fun getAiAlbumImageList(): List<String>
 }

--- a/app/src/main/java/com/capstone/artwhale/domain/repository/MoodRepository.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/repository/MoodRepository.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.domain.repository
+
+import com.capstone.artwhale.domain.model.Mood
+
+interface MoodRepository {
+
+    suspend fun getMoodList(): List<Mood>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/album/GetAiAlbumImageListUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/album/GetAiAlbumImageListUseCase.kt
@@ -1,0 +1,12 @@
+package com.capstone.artwhale.domain.usecase.album
+
+import com.capstone.artwhale.domain.model.Mood
+
+interface GetAiAlbumImageListUseCase {
+
+    suspend operator fun invoke(
+        title: String,
+        lyrics: String,
+        mood: Mood? = null
+    ): Result<List<String>>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/album/impl/GetAiAlbumImageListUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/album/impl/GetAiAlbumImageListUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.capstone.artwhale.domain.usecase.album.impl
+
+import com.capstone.artwhale.domain.model.Mood
+import com.capstone.artwhale.domain.repository.AlbumRepository
+import com.capstone.artwhale.domain.usecase.album.GetAiAlbumImageListUseCase
+import javax.inject.Inject
+
+class GetAiAlbumImageListUseCaseImpl @Inject constructor(
+    private val albumRepository: AlbumRepository
+) : GetAiAlbumImageListUseCase {
+
+    override suspend operator fun invoke(
+        title: String,
+        lyrics: String,
+        mood: Mood?
+    ): Result<List<String>> = runCatching { albumRepository.getAiAlbumImageList() }
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/mood/GetMoodListUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/mood/GetMoodListUseCase.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.domain.usecase.mood
+
+import com.capstone.artwhale.domain.model.Mood
+
+interface GetMoodListUseCase {
+
+    suspend operator fun invoke(): Result<List<Mood>>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/mood/impl/GetMoodListUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/mood/impl/GetMoodListUseCaseImpl.kt
@@ -1,0 +1,14 @@
+package com.capstone.artwhale.domain.usecase.mood.impl
+
+import com.capstone.artwhale.domain.model.Mood
+import com.capstone.artwhale.domain.repository.MoodRepository
+import com.capstone.artwhale.domain.usecase.mood.GetMoodListUseCase
+import javax.inject.Inject
+
+class GetMoodListUseCaseImpl @Inject constructor(
+    private val moodRepository: MoodRepository
+) : GetMoodListUseCase {
+
+    override suspend operator fun invoke(): Result<List<Mood>> =
+        runCatching { moodRepository.getMoodList() }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/common/BaseFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/common/BaseFragment.kt
@@ -1,4 +1,4 @@
-package com.capstone.artwhale.presentation.home
+package com.capstone.artwhale.presentation.common
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,7 +10,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.viewbinding.ViewBinding
 import com.capstone.artwhale.R
 import com.capstone.artwhale.domain.model.Music
-import com.capstone.artwhale.presentation.common.Inflate
 import com.capstone.artwhale.presentation.home.play.MusicPlayerFragment
 
 abstract class BaseFragment<VB : ViewBinding>(

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumFragment.kt
@@ -1,5 +1,6 @@
 package com.capstone.artwhale.presentation.home.album
 
+import android.content.Intent
 import android.os.Build
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -10,6 +11,7 @@ import com.capstone.artwhale.domain.model.Album
 import com.capstone.artwhale.presentation.home.BaseFragment
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRankingThumbnailRVAdapter
+import com.capstone.artwhale.presentation.register.album.AlbumRegisterActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.launchIn
@@ -45,6 +47,13 @@ class AlbumFragment : BaseFragment<FragmentAlbumBinding>(FragmentAlbumBinding::i
                 .launchIn(this@AlbumFragment.lifecycleScope)
             showAlbum.onEach { albumRVAdapter.submitList(it) }
                 .launchIn(this@AlbumFragment.lifecycleScope)
+            clickListener.onEach {
+                if (it == null) return@onEach
+                val intent = Intent(requireContext(), AlbumRegisterActivity::class.java)
+                when (it) {
+                    R.id.iv_default -> startActivity(intent)
+                }
+            }.launchIn(this@AlbumFragment.lifecycleScope)
         }
     }
 
@@ -101,6 +110,7 @@ class AlbumFragment : BaseFragment<FragmentAlbumBinding>(FragmentAlbumBinding::i
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             requireActivity().window.statusBarColor =
                 resources.getColor(android.R.color.transparent, null)
+        viewModel.onClickButton(null)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumFragment.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.PagerSnapHelper
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentAlbumBinding
 import com.capstone.artwhale.domain.model.Album
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRankingThumbnailRVAdapter
 import com.capstone.artwhale.presentation.register.album.AlbumRegisterActivity

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumViewModel.kt
@@ -1,5 +1,6 @@
 package com.capstone.artwhale.presentation.home.album
 
+import android.view.View
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capstone.artwhale.domain.model.Album
@@ -21,6 +22,9 @@ class AlbumViewModel @Inject constructor(
     private val getAllAlbumUseCase: GetAllAlbumUseCase,
     private val getAlbumRankingUseCase: GetAlbumRankingUseCase
 ) : ViewModel() {
+
+    private val _clickListener = MutableStateFlow<Int?>(null)
+    val clickListener: StateFlow<Int?> = _clickListener
 
     private val _albumRanking = MutableStateFlow<List<Album>>(emptyList())
     private var _allAlbum = emptyList<Album>()
@@ -57,5 +61,9 @@ class AlbumViewModel @Inject constructor(
             }.onFailure { _state.emit(Error(it.message)) }
             searchFlow.collect()
         }
+    }
+
+    fun onClickButton(view: View?) {
+        viewModelScope.launch { _clickListener.emit(view?.id) }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/music/MusicFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/music/MusicFragment.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.PagerSnapHelper
 import com.capstone.artwhale.databinding.FragmentMusicBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.music.adapter.MusicChartRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.NewMusicRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.NoticeRVAdapter

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/music/MusicFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/music/MusicFragment.kt
@@ -1,13 +1,16 @@
 package com.capstone.artwhale.presentation.home.music
 
+import android.content.Intent
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.PagerSnapHelper
+import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentMusicBinding
 import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.music.adapter.MusicChartRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.NewMusicRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.NoticeRVAdapter
+import com.capstone.artwhale.presentation.register.music.MusicRegisterActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.launchIn
@@ -28,6 +31,18 @@ class MusicFragment : BaseFragment<FragmentMusicBinding>(FragmentMusicBinding::i
     override fun initAfterBinding() {
         initRecyclerView()
         initObserver()
+        initToolBar()
+    }
+
+    private fun initToolBar() {
+        with(binding.ctbMain) {
+            setOnClickDefaultIcon {
+                startActivity(Intent(requireContext(), MusicRegisterActivity::class.java))
+            }
+            setOnClickAdditionalIcon {
+                graphNavigate(R.id.action_to_SearchFragment)
+            }
+        }
     }
 
     private fun initRecyclerView() {

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/ProfileFragment.kt
@@ -13,7 +13,7 @@ import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentProfileBinding
 import com.capstone.artwhale.domain.model.Album
 import com.capstone.artwhale.domain.model.Music
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.UserViewModel
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.MusicChartRVAdapter

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoEditorFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoEditorFragment.kt
@@ -6,7 +6,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentUserInfoEditorBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.UserViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoFragment.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentUserInfoBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.UserViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/like/LikeFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/like/LikeFragment.kt
@@ -5,7 +5,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.navigation.fragment.findNavController
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentLikeBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.profile.common.adapter.ListVPAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/my/MyArtFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/my/MyArtFragment.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.activity.OnBackPressedCallback
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentMyArtBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.home.profile.common.adapter.ListVPAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterActivity.kt
@@ -1,19 +1,49 @@
 package com.capstone.artwhale.presentation.register.album
 
+import android.net.Uri
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import com.capstone.artwhale.databinding.ActivityAlbumRegisterBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AlbumRegisterActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityAlbumRegisterBinding
+    private val viewModel by viewModels<AlbumRegisterViewModel>()
+
+    private val getContent =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            try {
+                uri?.apply { viewModel.setAlbumImage(uri) }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
 
         binding = ActivityAlbumRegisterBinding.inflate(layoutInflater)
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = this
         setContentView(binding.root)
+
+        initButton()
+        initSpinner()
+    }
+
+    private fun initSpinner() {}
+
+    private fun initButton() {
+        with(binding) {
+            ivAlbumThumbnail.setOnClickListener { getContent.launch("image/*") }
+            cvRegister.setOnClickListener {}
+            ctbSub.setOnClickDefaultIcon { finish() }
+        }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterActivity.kt
@@ -1,0 +1,19 @@
+package com.capstone.artwhale.presentation.register.album
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import com.capstone.artwhale.databinding.ActivityAlbumRegisterBinding
+
+class AlbumRegisterActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityAlbumRegisterBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityAlbumRegisterBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterActivity.kt
@@ -2,12 +2,19 @@ package com.capstone.artwhale.presentation.register.album
 
 import android.net.Uri
 import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.databinding.ActivityAlbumRegisterBinding
+import com.capstone.artwhale.domain.model.Mood
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class AlbumRegisterActivity : AppCompatActivity() {
@@ -34,10 +41,27 @@ class AlbumRegisterActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         initButton()
-        initSpinner()
+        initObserver()
     }
 
-    private fun initSpinner() {}
+    private fun initObserver() {
+        viewModel.moodList.onEach {
+            initSpinner(it)
+            if (it.isNotEmpty()) viewModel.selectMood(0)
+        }.launchIn(this.lifecycleScope)
+    }
+
+    private fun initSpinner(list: List<Mood>) {
+        val adapter =
+            ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, list.map { it.name })
+        binding.spinner.adapter = adapter
+        binding.spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, pos: Int, id: Long) =
+                viewModel.selectMood(pos)
+
+            override fun onNothingSelected(parent: AdapterView<*>) = Unit
+        }
+    }
 
     private fun initButton() {
         with(binding) {

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterViewModel.kt
@@ -19,9 +19,11 @@ class AlbumRegisterViewModel @Inject constructor(
 
     private val _imageUri = MutableStateFlow<String?>(null)
     private val _moodList = MutableStateFlow<List<Mood>>(emptyList())
+    private val _selectedMood = MutableStateFlow<Mood?>(null)
 
     val imageUri: StateFlow<String?> = _imageUri
     val moodList: StateFlow<List<Mood>> = _moodList
+    val selectedMood: StateFlow<Mood?> = _selectedMood
     val title = MutableStateFlow("")
 
     init {
@@ -32,5 +34,9 @@ class AlbumRegisterViewModel @Inject constructor(
 
     fun setAlbumImage(uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) { _imageUri.emit(uri.toString()) }
+    }
+
+    fun selectMood(moodIdx: Int) {
+        viewModelScope.launch(Dispatchers.IO) { _selectedMood.emit(moodList.value[moodIdx]) }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterViewModel.kt
@@ -1,0 +1,24 @@
+package com.capstone.artwhale.presentation.register.album
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AlbumRegisterViewModel @Inject constructor() : ViewModel() {
+
+    private val _imageUri = MutableStateFlow<String?>(null)
+
+    val imageUri: StateFlow<String?> = _imageUri
+    val title = MutableStateFlow("")
+
+    fun setAlbumImage(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) { _imageUri.emit(uri.toString()) }
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/album/AlbumRegisterViewModel.kt
@@ -3,6 +3,8 @@ package com.capstone.artwhale.presentation.register.album
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.capstone.artwhale.domain.model.Mood
+import com.capstone.artwhale.domain.usecase.mood.GetMoodListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,12 +13,22 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class AlbumRegisterViewModel @Inject constructor() : ViewModel() {
+class AlbumRegisterViewModel @Inject constructor(
+    private val getMoodListUseCase: GetMoodListUseCase
+) : ViewModel() {
 
     private val _imageUri = MutableStateFlow<String?>(null)
+    private val _moodList = MutableStateFlow<List<Mood>>(emptyList())
 
     val imageUri: StateFlow<String?> = _imageUri
+    val moodList: StateFlow<List<Mood>> = _moodList
     val title = MutableStateFlow("")
+
+    init {
+        viewModelScope.launch {
+            getMoodListUseCase().onSuccess { _moodList.emit(it) }
+        }
+    }
 
     fun setAlbumImage(uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) { _imageUri.emit(uri.toString()) }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import com.capstone.artwhale.databinding.ActivityMusicRegisterBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MusicRegisterActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMusicRegisterBinding
@@ -14,6 +16,7 @@ class MusicRegisterActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         binding = ActivityMusicRegisterBinding.inflate(layoutInflater)
+        binding.lifecycleOwner = this
         setContentView(binding.root)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.NavHostFragment
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.ActivityMusicRegisterBinding
 import com.capstone.artwhale.domain.model.Album
@@ -30,6 +31,14 @@ class MusicRegisterActivity : AppCompatActivity() {
         data?.let { viewModel.setAlbum(it) }
 
         initObserver()
+        initButton()
+    }
+
+    private fun initButton() {
+        with(binding) {
+            ctbSub.setOnClickDefaultIcon { onBackPressed() }
+            ctbSub.setOnClickAdditionalIcon { finish() }
+        }
     }
 
     private fun initObserver() {
@@ -37,5 +46,15 @@ class MusicRegisterActivity : AppCompatActivity() {
             val text = (if (it) "AI " else "") + getString(R.string.activity_music_register)
             binding.ctbSub.setAppBarTitle(text)
         }.launchIn(this.lifecycleScope)
+    }
+
+    override fun onBackPressed() {
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.fcv_content)
+        val navController = (navHostFragment as NavHostFragment).navController
+        when (navController.currentDestination?.id) {
+            R.id.musicUploadFragment -> finish()
+            R.id.aIAlbumSelectFragment -> navController.navigate(R.id.action_music_upload)
+            else -> finish()
+        }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
@@ -1,15 +1,22 @@
 package com.capstone.artwhale.presentation.register.music
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
+import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.ActivityMusicRegisterBinding
+import com.capstone.artwhale.domain.model.Album
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class MusicRegisterActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMusicRegisterBinding
+    private val viewModel by viewModels<MusicRegisterViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -18,5 +25,17 @@ class MusicRegisterActivity : AppCompatActivity() {
         binding = ActivityMusicRegisterBinding.inflate(layoutInflater)
         binding.lifecycleOwner = this
         setContentView(binding.root)
+
+        val data = intent.getSerializableExtra("album") as Album?
+        data?.let { viewModel.setAlbum(it) }
+
+        initObserver()
+    }
+
+    private fun initObserver() {
+        viewModel.isAI.onEach {
+            val text = (if (it) "AI " else "") + getString(R.string.activity_music_register)
+            binding.ctbSub.setAppBarTitle(text)
+        }.launchIn(this.lifecycleScope)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
@@ -1,6 +1,8 @@
 package com.capstone.artwhale.presentation.register.music
 
+import android.net.Uri
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
@@ -19,12 +21,22 @@ class MusicRegisterActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMusicRegisterBinding
     private val viewModel by viewModels<MusicRegisterViewModel>()
 
+    private val getContent =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            try {
+                uri?.apply { viewModel.setMusic(uri) }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
 
         binding = ActivityMusicRegisterBinding.inflate(layoutInflater)
         binding.lifecycleOwner = this
+        binding.viewModel = viewModel
         setContentView(binding.root)
 
         val data = intent.getSerializableExtra("album") as Album?
@@ -38,6 +50,7 @@ class MusicRegisterActivity : AppCompatActivity() {
         with(binding) {
             ctbSub.setOnClickDefaultIcon { onBackPressed() }
             ctbSub.setOnClickAdditionalIcon { finish() }
+            btnUploadMusic.setOnClickListener { getContent.launch("audio/*") }
         }
     }
 
@@ -53,7 +66,10 @@ class MusicRegisterActivity : AppCompatActivity() {
         val navController = (navHostFragment as NavHostFragment).navController
         when (navController.currentDestination?.id) {
             R.id.musicUploadFragment -> finish()
-            R.id.aIAlbumSelectFragment -> navController.navigate(R.id.action_music_upload)
+            R.id.aIAlbumSelectFragment -> {
+                viewModel.clearAiImageList()
+                navController.navigate(R.id.action_music_upload)
+            }
             else -> finish()
         }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterActivity.kt
@@ -1,0 +1,19 @@
+package com.capstone.artwhale.presentation.register.music
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import com.capstone.artwhale.databinding.ActivityMusicRegisterBinding
+
+class MusicRegisterActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMusicRegisterBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityMusicRegisterBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
@@ -24,11 +24,11 @@ class MusicRegisterViewModel @Inject constructor(
     val isAI: StateFlow<Boolean> get() = _isAI
     val album: StateFlow<Album?> get() = _album
 
-    private val _imageUri = MutableStateFlow<String?>(null)
+    private val _musicUri = MutableStateFlow<Uri?>(null)
     private val _moodList = MutableStateFlow<List<Mood>>(emptyList())
     private val _selectedMood = MutableStateFlow<Mood?>(null)
 
-    val imageUri: StateFlow<String?> = _imageUri
+    val musicUri: StateFlow<Uri?> = _musicUri
     val moodList: StateFlow<List<Mood>> = _moodList
     val selectedMood: StateFlow<Mood?> = _selectedMood
     val title = MutableStateFlow("")
@@ -40,8 +40,8 @@ class MusicRegisterViewModel @Inject constructor(
         }
     }
 
-    fun setAlbumImage(uri: Uri) {
-        viewModelScope.launch(Dispatchers.IO) { _imageUri.emit(uri.toString()) }
+    fun setMusic(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) { _musicUri.emit(uri) }
     }
 
     fun selectMood(moodIdx: Int) {

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capstone.artwhale.domain.model.Album
 import com.capstone.artwhale.domain.model.Mood
+import com.capstone.artwhale.domain.usecase.album.GetAiAlbumImageListUseCase
 import com.capstone.artwhale.domain.usecase.mood.GetMoodListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MusicRegisterViewModel @Inject constructor(
-    private val getMoodListUseCase: GetMoodListUseCase
+    private val getMoodListUseCase: GetMoodListUseCase,
+    private val getAiAlbumImageListUseCase: GetAiAlbumImageListUseCase
 ) : ViewModel() {
 
     /*초기 설정 변수*/
@@ -27,12 +29,14 @@ class MusicRegisterViewModel @Inject constructor(
     private val _musicUri = MutableStateFlow<Uri?>(null)
     private val _moodList = MutableStateFlow<List<Mood>>(emptyList())
     private val _selectedMood = MutableStateFlow<Mood?>(null)
+    private val _aiAlbumImageList = MutableStateFlow<List<String>>(emptyList())
 
     val musicUri: StateFlow<Uri?> = _musicUri
     val moodList: StateFlow<List<Mood>> = _moodList
     val selectedMood: StateFlow<Mood?> = _selectedMood
     val title = MutableStateFlow("")
     val content = MutableStateFlow("")
+    val aiAlbumImageList: StateFlow<List<String>> = _aiAlbumImageList
 
     init {
         viewModelScope.launch {
@@ -52,6 +56,15 @@ class MusicRegisterViewModel @Inject constructor(
         viewModelScope.launch {
             _isAI.emit(false)
             _album.emit(album)
+        }
+    }
+
+    fun getAiAlbumImageList() {
+        viewModelScope.launch {
+            getAiAlbumImageListUseCase(
+                title.value,
+                content.value
+            ).onSuccess { _aiAlbumImageList.emit(it) }
         }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
@@ -44,6 +44,10 @@ class MusicRegisterViewModel @Inject constructor(
         }
     }
 
+    fun clearAiImageList() {
+        viewModelScope.launch(Dispatchers.IO) { _aiAlbumImageList.emit(emptyList()) }
+    }
+
     fun setMusic(uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) { _musicUri.emit(uri) }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/MusicRegisterViewModel.kt
@@ -1,0 +1,57 @@
+package com.capstone.artwhale.presentation.register.music
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.capstone.artwhale.domain.model.Album
+import com.capstone.artwhale.domain.model.Mood
+import com.capstone.artwhale.domain.usecase.mood.GetMoodListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MusicRegisterViewModel @Inject constructor(
+    private val getMoodListUseCase: GetMoodListUseCase
+) : ViewModel() {
+
+    /*초기 설정 변수*/
+    private val _isAI = MutableStateFlow(true)
+    private val _album = MutableStateFlow<Album?>(null)
+    val isAI: StateFlow<Boolean> get() = _isAI
+    val album: StateFlow<Album?> get() = _album
+
+    private val _imageUri = MutableStateFlow<String?>(null)
+    private val _moodList = MutableStateFlow<List<Mood>>(emptyList())
+    private val _selectedMood = MutableStateFlow<Mood?>(null)
+
+    val imageUri: StateFlow<String?> = _imageUri
+    val moodList: StateFlow<List<Mood>> = _moodList
+    val selectedMood: StateFlow<Mood?> = _selectedMood
+    val title = MutableStateFlow("")
+    val content = MutableStateFlow("")
+
+    init {
+        viewModelScope.launch {
+            getMoodListUseCase().onSuccess { _moodList.emit(it) }
+        }
+    }
+
+    fun setAlbumImage(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) { _imageUri.emit(uri.toString()) }
+    }
+
+    fun selectMood(moodIdx: Int) {
+        viewModelScope.launch(Dispatchers.IO) { _selectedMood.emit(moodList.value[moodIdx]) }
+    }
+
+    fun setAlbum(album: Album) {
+        viewModelScope.launch {
+            _isAI.emit(false)
+            _album.emit(album)
+        }
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
@@ -1,7 +1,7 @@
 package com.capstone.artwhale.presentation.register.music.ai
 
 import com.capstone.artwhale.databinding.FragmentAiAlbumSelectBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 
 class AIAlbumSelectFragment :
     BaseFragment<FragmentAiAlbumSelectBinding>(FragmentAiAlbumSelectBinding::inflate) {

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.databinding.FragmentAiAlbumSelectBinding
 import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel
+import com.capstone.artwhale.presentation.register.music.ai.adapter.AiImageRVAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -14,17 +15,28 @@ class AIAlbumSelectFragment :
     BaseFragment<FragmentAiAlbumSelectBinding>(FragmentAiAlbumSelectBinding::inflate) {
 
     private val viewModel by activityViewModels<MusicRegisterViewModel>()
+    private lateinit var aiImageRVAdapter: AiImageRVAdapter
 
     override fun initAfterBinding() {
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
 
+        initRecyclerView()
         initObserver()
+    }
+
+    private fun clickImage(url: String) {
+
+    }
+
+    private fun initRecyclerView() {
+        aiImageRVAdapter = AiImageRVAdapter().apply { setCallBack { clickImage(it) } }
+        binding.rvAiImage.adapter = aiImageRVAdapter
     }
 
     private fun initObserver() {
         viewModel.aiAlbumImageList.onEach {
-
+            aiImageRVAdapter.submitList(it)
         }.launchIn(this.lifecycleScope)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
@@ -1,11 +1,30 @@
 package com.capstone.artwhale.presentation.register.music.ai
 
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.databinding.FragmentAiAlbumSelectBinding
 import com.capstone.artwhale.presentation.common.BaseFragment
+import com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class AIAlbumSelectFragment :
     BaseFragment<FragmentAiAlbumSelectBinding>(FragmentAiAlbumSelectBinding::inflate) {
-    override fun initAfterBinding() {
 
+    private val viewModel by activityViewModels<MusicRegisterViewModel>()
+
+    override fun initAfterBinding() {
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = this
+
+        initObserver()
+    }
+
+    private fun initObserver() {
+        viewModel.aiAlbumImageList.onEach {
+
+        }.launchIn(this.lifecycleScope)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/AIAlbumSelectFragment.kt
@@ -1,0 +1,11 @@
+package com.capstone.artwhale.presentation.register.music.ai
+
+import com.capstone.artwhale.databinding.FragmentAiAlbumSelectBinding
+import com.capstone.artwhale.presentation.home.BaseFragment
+
+class AIAlbumSelectFragment :
+    BaseFragment<FragmentAiAlbumSelectBinding>(FragmentAiAlbumSelectBinding::inflate) {
+    override fun initAfterBinding() {
+
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/adapter/AiImageRVAdapter.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/adapter/AiImageRVAdapter.kt
@@ -1,0 +1,39 @@
+package com.capstone.artwhale.presentation.register.music.ai.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.capstone.artwhale.databinding.ItemAiImageBinding
+import com.capstone.artwhale.presentation.register.music.ai.viewholder.AiImageViewHolder
+
+class AiImageRVAdapter : ListAdapter<String, AiImageViewHolder>(diffUtil) {
+
+    private var callback: (url: String) -> Unit = {}
+
+    fun setCallBack(callback: (url: String) -> Unit) {
+        this.callback = callback
+    }
+
+    override fun onBindViewHolder(holder: AiImageViewHolder, position: Int) {
+        holder.bind(getItem(position), callback)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AiImageViewHolder {
+        return AiImageViewHolder(
+            ItemAiImageBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<String>() {
+            override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/viewholder/AiImageViewHolder.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/ai/viewholder/AiImageViewHolder.kt
@@ -1,0 +1,12 @@
+package com.capstone.artwhale.presentation.register.music.ai.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.capstone.artwhale.databinding.ItemAiImageBinding
+
+class AiImageViewHolder(private val binding: ItemAiImageBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(url: String, callback: (url: String) -> Unit) {
+        binding.url = url
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
@@ -1,13 +1,21 @@
 package com.capstone.artwhale.presentation.register.music.upload
 
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentMusicUploadBinding
+import com.capstone.artwhale.domain.model.Mood
 import com.capstone.artwhale.presentation.common.BaseFragment
 import com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MusicUploadFragment :
@@ -20,12 +28,52 @@ class MusicUploadFragment :
         binding.lifecycleOwner = this
 
         initObserver()
+        initButton()
+    }
+
+    private fun initSpinner(list: List<Mood>) {
+        val adapter = ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_spinner_dropdown_item,
+            list.map { it.name })
+        binding.spinner.adapter = adapter
+        binding.spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, pos: Int, id: Long) =
+                viewModel.selectMood(pos)
+
+            override fun onNothingSelected(parent: AdapterView<*>) = Unit
+        }
+    }
+
+    private fun initButton() {
+        with(binding) {
+            btnRegister.setOnClickListener {
+                if (viewModel!!.isAI.value) graphNavigate(R.id.action_to_ai_album_select)
+                else requireActivity().finish()
+            }
+        }
     }
 
     private fun initObserver() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                launch {
+                    viewModel.isAI.collect {
+                        val text = if (it) "Run" else "Register"
+                        binding.btnRegister.text = text
+                    }
+                }
+                launch { viewModel.moodList.collect { initSpinner(it) } }
+                launch {
+                    viewModel.musicUri.collect {
+                        binding.btnRegister.isEnabled = it != null
+                    }
+                }
+            }
+        }
         viewModel.isAI.onEach {
             val text = if (it) "Run" else "Register"
-            binding.tvRegister.text = text
+            binding.btnRegister.text = text
         }.launchIn(this.lifecycleScope)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
@@ -1,0 +1,11 @@
+package com.capstone.artwhale.presentation.register.music.upload
+
+import com.capstone.artwhale.databinding.FragmentMusicUploadBinding
+import com.capstone.artwhale.presentation.home.BaseFragment
+
+class MusicUploadFragment :
+    BaseFragment<FragmentMusicUploadBinding>(FragmentMusicUploadBinding::inflate) {
+    override fun initAfterBinding() {
+
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
@@ -1,11 +1,31 @@
 package com.capstone.artwhale.presentation.register.music.upload
 
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.databinding.FragmentMusicUploadBinding
 import com.capstone.artwhale.presentation.common.BaseFragment
+import com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class MusicUploadFragment :
     BaseFragment<FragmentMusicUploadBinding>(FragmentMusicUploadBinding::inflate) {
-    override fun initAfterBinding() {
 
+    private val viewModel by activityViewModels<MusicRegisterViewModel>()
+
+    override fun initAfterBinding() {
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = this
+
+        initObserver()
+    }
+
+    private fun initObserver() {
+        viewModel.isAI.onEach {
+            val text = if (it) "Run" else "Register"
+            binding.tvRegister.text = text
+        }.launchIn(this.lifecycleScope)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
@@ -1,7 +1,7 @@
 package com.capstone.artwhale.presentation.register.music.upload
 
 import com.capstone.artwhale.databinding.FragmentMusicUploadBinding
-import com.capstone.artwhale.presentation.home.BaseFragment
+import com.capstone.artwhale.presentation.common.BaseFragment
 
 class MusicUploadFragment :
     BaseFragment<FragmentMusicUploadBinding>(FragmentMusicUploadBinding::inflate) {

--- a/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/register/music/upload/MusicUploadFragment.kt
@@ -48,7 +48,7 @@ class MusicUploadFragment :
     private fun initButton() {
         with(binding) {
             btnRegister.setOnClickListener {
-                if (viewModel!!.isAI.value) graphNavigate(R.id.action_to_ai_album_select)
+                if (viewModel!!.isAI.value) viewModel!!.getAiAlbumImageList()
                 else requireActivity().finish()
             }
         }
@@ -67,6 +67,11 @@ class MusicUploadFragment :
                 launch {
                     viewModel.musicUri.collect {
                         binding.btnRegister.isEnabled = it != null
+                    }
+                }
+                launch {
+                    viewModel.aiAlbumImageList.collect {
+                        if (it.isNotEmpty()) graphNavigate(R.id.action_to_ai_album_select)
                     }
                 }
             }

--- a/app/src/main/res/drawable/bg_button_selector.xml
+++ b/app/src/main/res/drawable/bg_button_selector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary" android:state_enabled="true">
+        <shape>
+            <solid android:color="@color/primary" />
+            <corners android:bottomLeftRadius="50dp" android:bottomRightRadius="50dp" android:topLeftRadius="50dp" android:topRightRadius="50dp" />
+        </shape>
+    </item>
+    <item android:color="@color/accent" android:state_enabled="false">
+        <shape>
+            <solid android:color="@color/accent" />
+            <corners android:bottomLeftRadius="50dp" android:bottomRightRadius="50dp" android:topLeftRadius="50dp" android:topRightRadius="50dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/ic_fast_forward.xml
+++ b/app/src/main/res/drawable/ic_fast_forward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19 13.15L23.04 16 19 18.85v-5.7Zm-12 0L11.04 16 7 18.85v-5.7ZM16.33 8v16l11.34-8-11.34-8Zm-12 0v16l11.34-8L4.33 8Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_fast_rewind.xml
+++ b/app/src/main/res/drawable/ic_fast_rewind.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M25 13.15v5.7L20.96 16 25 13.15Zm-12 0v5.7L8.96 16 13 13.15ZM27.67 8l-11.34 8 11.34 8V8Zm-12 0L4.33 16l11.34 8V8Z"/>
+</vector>

--- a/app/src/main/res/layout/activity_album_register.xml
+++ b/app/src/main/res/layout/activity_album_register.xml
@@ -1,138 +1,150 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/bg_ivory"
-    android:fitsSystemWindows="true"
-    tools:context=".presentation.register.album.AlbumRegisterActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/abl_sub"
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.capstone.artwhale.presentation.register.album.AlbumRegisterViewModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:color/transparent"
+        android:layout_height="match_parent"
+        android:background="@color/bg_ivory"
         android:fitsSystemWindows="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        tools:context=".presentation.register.album.AlbumRegisterActivity">
 
-        <com.capstone.artwhale.presentation.common.CustomToolBar
-            android:id="@+id/ctb_sub"
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/abl_sub"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:setAdditionalIcon="@drawable/ic_mores"
-            app:setDefaultIcon="@drawable/ic_left_arrow"
-            app:toolBarType="sub"
-            app:toolbarTitle="@string/activity_album_register" />
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:fitsSystemWindows="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-    </com.google.android.material.appbar.AppBarLayout>
+            <com.capstone.artwhale.presentation.common.CustomToolBar
+                android:id="@+id/ctb_sub"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:setAdditionalIcon="@drawable/ic_mores"
+                app:setDefaultIcon="@drawable/ic_left_arrow"
+                app:toolBarType="sub"
+                app:toolbarTitle="@string/activity_album_register" />
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/iv_album_thumbnail"
-        image="@{music.albumImgUrl}"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_marginHorizontal="40dp"
-        android:layout_marginTop="40dp"
-        android:background="@color/black"
-        android:clickable="true"
-        android:focusable="true"
-        android:scaleType="centerCrop"
-        android:src="@drawable/img_logo_whale"
-        app:layout_constraintDimensionRatio="1:1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/abl_sub"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
+        </com.google.android.material.appbar.AppBarLayout>
 
-    <LinearLayout
-        android:id="@+id/ll_album_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="30dp"
-        android:layout_marginTop="20dp"
-        android:orientation="vertical"
-        android:paddingHorizontal="5dp"
-        app:layout_constraintTop_toBottomOf="@id/iv_album_thumbnail">
-
-        <EditText
-            android:id="@+id/et_album_title"
-            style="@style/title.small"
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_album_thumbnail"
+            image="@{viewModel.imageUri}"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_gravity="center"
-            android:layout_weight="1"
-            android:autofillHints="@null"
-            android:background="@android:color/transparent"
-            android:hint="@string/input_title"
-            android:inputType="textMultiLine|textNoSuggestions"
-            android:maxLines="1"
-            android:paddingHorizontal="15dp"
-            android:paddingVertical="5dp"
-            android:textColorHint="@color/gray40" />
+            android:layout_marginHorizontal="40dp"
+            android:layout_marginTop="40dp"
+            android:background="@color/black"
+            android:clickable="true"
+            android:focusable="true"
+            android:scaleType="centerCrop"
+            android:src="@drawable/img_logo_whale"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/abl_sub"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
 
-        <com.google.android.material.divider.MaterialDivider
+        <LinearLayout
+            android:id="@+id/ll_album_title"
             android:layout_width="match_parent"
-            android:layout_height="0.7dp"
-            android:layout_gravity="center"
-            android:src="@drawable/ic_magnifier"
-            app:dividerColor="@color/gray40"
-            app:tint="@color/white" />
-    </LinearLayout>
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="30dp"
+            android:layout_marginTop="20dp"
+            android:orientation="vertical"
+            android:paddingHorizontal="5dp"
+            app:layout_constraintTop_toBottomOf="@id/iv_album_thumbnail">
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="30dp"
-        android:layout_marginTop="20dp"
-        android:orientation="vertical"
-        android:paddingHorizontal="5dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ll_album_title">
+            <EditText
+                android:id="@+id/et_album_title"
+                style="@style/title.small"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:autofillHints="@null"
+                android:background="@android:color/transparent"
+                android:hint="@string/input_title"
+                android:inputType="textMultiLine|textNoSuggestions"
+                android:maxLines="1"
+                android:paddingHorizontal="15dp"
+                android:paddingVertical="5dp"
+                android:text="@={viewModel.title}"
+                android:textColorHint="@color/gray40" />
 
-        <androidx.appcompat.widget.AppCompatSpinner
-            android:id="@+id/spinner"
-            style="@style/title.small"
-            android:layout_width="130dp"
-            android:layout_height="0dp"
-            android:layout_gravity="center"
-            android:layout_weight="1"
-            android:background="@android:color/transparent"
-            android:paddingHorizontal="15dp"
-            android:paddingVertical="5dp"
-            android:textColorHint="@color/gray" />
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="0.7dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_magnifier"
+                app:dividerColor="@color/gray40"
+                app:tint="@color/white" />
+        </LinearLayout>
 
-        <com.google.android.material.divider.MaterialDivider
-            android:layout_width="match_parent"
-            android:layout_height="0.7dp"
-            android:layout_gravity="center"
-            android:src="@drawable/ic_magnifier"
-            app:dividerColor="@color/gray40" />
-    </LinearLayout>
-
-    <androidx.cardview.widget.CardView
-        android:id="@+id/cv_register"
-        android:layout_width="230dp"
-        android:layout_height="60dp"
-        android:layout_marginBottom="50dp"
-        android:clickable="true"
-        android:focusable="true"
-        app:cardBackgroundColor="@color/primary"
-        app:cardCornerRadius="100dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <TextView
-            android:id="@+id/tv_register"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="@string/register"
-            android:textAppearance="@style/button.bold" />
+            android:layout_marginHorizontal="30dp"
+            android:layout_marginTop="20dp"
+            android:orientation="vertical"
+            android:paddingHorizontal="5dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ll_album_title">
 
-    </androidx.cardview.widget.CardView>
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/spinner"
+                style="@style/title.small"
+                android:layout_width="130dp"
+                android:layout_height="20dp"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="15dp"
+                android:paddingVertical="5dp"
+                android:textColorHint="@color/gray" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="0.7dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_magnifier"
+                app:dividerColor="@color/gray40" />
+        </LinearLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_register"
+            android:layout_width="230dp"
+            android:layout_height="60dp"
+            android:layout_marginBottom="50dp"
+            android:clickable="true"
+            android:focusable="true"
+            app:cardBackgroundColor="@color/primary"
+            app:cardCornerRadius="100dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/tv_register"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/register"
+                android:textAppearance="@style/button.bold" />
+
+        </androidx.cardview.widget.CardView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_album_register.xml
+++ b/app/src/main/res/layout/activity_album_register.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_ivory"
+    android:fitsSystemWindows="true"
+    tools:context=".presentation.register.album.AlbumRegisterActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/abl_sub"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:fitsSystemWindows="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.capstone.artwhale.presentation.common.CustomToolBar
+            android:id="@+id/ctb_sub"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:setAdditionalIcon="@drawable/ic_mores"
+            app:setDefaultIcon="@drawable/ic_down_arrow"
+            app:toolBarType="sub"
+            app:toolbarTitle="@string/activity_album_register" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_album_register.xml
+++ b/app/src/main/res/layout/activity_album_register.xml
@@ -107,12 +107,10 @@
                 android:id="@+id/spinner"
                 style="@style/title.small"
                 android:layout_width="130dp"
-                android:layout_height="20dp"
+                android:layout_height="0dp"
                 android:layout_gravity="center"
                 android:layout_weight="1"
                 android:background="@android:color/transparent"
-                android:paddingHorizontal="15dp"
-                android:paddingVertical="5dp"
                 android:textColorHint="@color/gray" />
 
             <com.google.android.material.divider.MaterialDivider

--- a/app/src/main/res/layout/activity_album_register.xml
+++ b/app/src/main/res/layout/activity_album_register.xml
@@ -23,10 +23,116 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:setAdditionalIcon="@drawable/ic_mores"
-            app:setDefaultIcon="@drawable/ic_down_arrow"
+            app:setDefaultIcon="@drawable/ic_left_arrow"
             app:toolBarType="sub"
             app:toolbarTitle="@string/activity_album_register" />
 
     </com.google.android.material.appbar.AppBarLayout>
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/iv_album_thumbnail"
+        image="@{music.albumImgUrl}"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="40dp"
+        android:layout_marginTop="40dp"
+        android:background="@color/black"
+        android:clickable="true"
+        android:focusable="true"
+        android:scaleType="centerCrop"
+        android:src="@drawable/img_logo_whale"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/abl_sub"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
+
+    <LinearLayout
+        android:id="@+id/ll_album_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="30dp"
+        android:layout_marginTop="20dp"
+        android:orientation="vertical"
+        android:paddingHorizontal="5dp"
+        app:layout_constraintTop_toBottomOf="@id/iv_album_thumbnail">
+
+        <EditText
+            android:id="@+id/et_album_title"
+            style="@style/title.small"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            android:autofillHints="@null"
+            android:background="@android:color/transparent"
+            android:hint="@string/input_title"
+            android:inputType="textMultiLine|textNoSuggestions"
+            android:maxLines="1"
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="5dp"
+            android:textColorHint="@color/gray40" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="0.7dp"
+            android:layout_gravity="center"
+            android:src="@drawable/ic_magnifier"
+            app:dividerColor="@color/gray40"
+            app:tint="@color/white" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="30dp"
+        android:layout_marginTop="20dp"
+        android:orientation="vertical"
+        android:paddingHorizontal="5dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ll_album_title">
+
+        <androidx.appcompat.widget.AppCompatSpinner
+            android:id="@+id/spinner"
+            style="@style/title.small"
+            android:layout_width="130dp"
+            android:layout_height="0dp"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            android:background="@android:color/transparent"
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="5dp"
+            android:textColorHint="@color/gray" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="0.7dp"
+            android:layout_gravity="center"
+            android:src="@drawable/ic_magnifier"
+            app:dividerColor="@color/gray40" />
+    </LinearLayout>
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cv_register"
+        android:layout_width="230dp"
+        android:layout_height="60dp"
+        android:layout_marginBottom="50dp"
+        android:clickable="true"
+        android:focusable="true"
+        app:cardBackgroundColor="@color/primary"
+        app:cardCornerRadius="100dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            android:id="@+id/tv_register"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/register"
+            android:textAppearance="@style/button.bold" />
+
+    </androidx.cardview.widget.CardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -8,6 +8,8 @@
         <variable
             name="viewModel"
             type="com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel" />
+
+        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -41,17 +43,30 @@
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/btn_upload_music"
             android:layout_width="match_parent"
-            android:layout_height="155dp"
+            android:layout_height="145dp"
+            android:layout_marginHorizontal="25dp"
             android:layout_marginTop="20dp"
             android:background="@color/primary"
-            android:paddingHorizontal="25dp"
-            android:paddingVertical="20dp"
             android:src="@drawable/ic_plus"
             android:tint="@color/white"
-            app:contentPadding="40dp"
+            app:contentPadding="45dp"
             app:layout_constraintTop_toBottomOf="@id/abl_sub"
             app:shapeAppearance="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
 
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="145dp"
+            android:layout_marginHorizontal="25dp"
+            android:visibility="@{viewModel.musicUri == null ? View.GONE : View.VISIBLE}"
+            app:cardBackgroundColor="@color/accent"
+            app:cardCornerRadius="13dp"
+            app:cardElevation="0dp"
+            app:layout_constraintBottom_toBottomOf="@id/btn_upload_music"
+            app:layout_constraintEnd_toEndOf="@id/btn_upload_music"
+            app:layout_constraintStart_toStartOf="@id/btn_upload_music"
+            app:layout_constraintTop_toTopOf="@id/btn_upload_music">
+
+        </androidx.cardview.widget.CardView>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fcv_content"

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -32,7 +32,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:setAdditionalIcon="@drawable/ic_mores"
-                app:setDefaultIcon="@drawable/ic_down_arrow"
+                app:setDefaultIcon="@drawable/ic_left_arrow"
                 app:toolBarType="sub"
                 app:toolbarTitle="@string/activity_music_register" />
 

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -1,32 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/bg_ivory"
-    android:fitsSystemWindows="true"
-    tools:context=".presentation.register.music.MusicRegisterActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/abl_sub"
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:color/transparent"
+        android:layout_height="match_parent"
+        android:background="@color/bg_ivory"
         android:fitsSystemWindows="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        tools:context=".presentation.register.music.MusicRegisterActivity">
 
-        <com.capstone.artwhale.presentation.common.CustomToolBar
-            android:id="@+id/ctb_sub"
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/abl_sub"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:setAdditionalIcon="@drawable/ic_mores"
-            app:setDefaultIcon="@drawable/ic_down_arrow"
-            app:toolBarType="sub"
-            app:toolbarTitle="@string/activity_music_register" />
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:fitsSystemWindows="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-    </com.google.android.material.appbar.AppBarLayout>
+            <com.capstone.artwhale.presentation.common.CustomToolBar
+                android:id="@+id/ctb_sub"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:setAdditionalIcon="@drawable/ic_mores"
+                app:setDefaultIcon="@drawable/ic_down_arrow"
+                app:toolBarType="sub"
+                app:toolbarTitle="@string/activity_music_register" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/btn_upload_music"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:background="@color/primary"
+            android:paddingHorizontal="25dp"
+            android:paddingVertical="30dp"
+            android:src="@drawable/ic_plus"
+            android:tint="@color/white"
+            app:contentPadding="70dp"
+            app:layout_constraintTop_toBottomOf="@id/abl_sub"
+            app:shapeAppearance="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
+
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fcv_content"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:defaultNavHost="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_upload_music"
+            app:navGraph="@navigation/nav_music_register_graph" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_ivory"
+    android:fitsSystemWindows="true"
+    tools:context=".presentation.register.music.MusicRegisterActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/abl_sub"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:fitsSystemWindows="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.capstone.artwhale.presentation.common.CustomToolBar
+            android:id="@+id/ctb_sub"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:setAdditionalIcon="@drawable/ic_mores"
+            app:setDefaultIcon="@drawable/ic_down_arrow"
+            app:toolBarType="sub"
+            app:toolbarTitle="@string/activity_music_register" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -66,6 +66,100 @@
             app:layout_constraintStart_toStartOf="@id/btn_upload_music"
             app:layout_constraintTop_toTopOf="@id/btn_upload_music">
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="10dp">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:id="@+id/iv_album_thumbnail"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:background="@color/primary"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintDimensionRatio="1:1"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:shapeAppearance="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="AI"
+                    android:textAppearance="@style/title.small.white"
+                    android:visibility="@{viewModel.album != null ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_album_thumbnail"
+                    app:layout_constraintEnd_toEndOf="@id/iv_album_thumbnail"
+                    app:layout_constraintStart_toStartOf="@id/iv_album_thumbnail"
+                    app:layout_constraintTop_toTopOf="@id/iv_album_thumbnail" />
+
+                <ImageView
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:layout_marginStart="10dp"
+                    android:src="@drawable/ic_fast_rewind"
+                    app:layout_constraintBottom_toBottomOf="@id/btn_play"
+                    app:layout_constraintEnd_toStartOf="@id/btn_play"
+                    app:layout_constraintStart_toEndOf="@id/iv_album_thumbnail"
+                    app:layout_constraintTop_toTopOf="@id/btn_play" />
+
+                <ImageView
+                    android:id="@+id/btn_play"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_marginBottom="20dp"
+                    android:background="@android:color/transparent"
+                    android:src="@drawable/ic_player_play_selector"
+                    app:layout_constraintBottom_toTopOf="@id/sb_music_progress"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/iv_album_thumbnail"
+                    app:layout_constraintTop_toTopOf="@+id/iv_album_thumbnail"
+                    app:layout_constraintVertical_chainStyle="packed" />
+
+                <ImageView
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:layout_marginEnd="10dp"
+                    android:src="@drawable/ic_fast_forward"
+                    app:layout_constraintBottom_toBottomOf="@id/btn_play"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/btn_play"
+                    app:layout_constraintTop_toTopOf="@id/btn_play" />
+
+                <SeekBar
+                    android:id="@+id/sb_music_progress"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layerType="software"
+                    android:progress="50"
+                    android:progressTint="@color/primary"
+                    android:thumbTint="@color/primary"
+                    app:layout_constraintBottom_toBottomOf="@+id/iv_album_thumbnail"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/iv_album_thumbnail"
+                    app:layout_constraintTop_toBottomOf="@id/btn_play"
+                    app:layout_constraintVertical_chainStyle="packed" />
+
+                <TextView
+                    android:id="@+id/tv_play_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:text="0:00"
+                    android:textAppearance="@style/text.verySmall"
+                    app:layout_constraintStart_toStartOf="@id/sb_music_progress"
+                    app:layout_constraintTop_toBottomOf="@id/sb_music_progress" />
+
+                <TextView
+                    android:id="@+id/tv_end_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="12dp"
+                    android:text="3:00"
+                    android:textAppearance="@style/text.verySmall"
+                    app:layout_constraintEnd_toEndOf="@id/sb_music_progress"
+                    app:layout_constraintTop_toBottomOf="@id/sb_music_progress" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
 
         <androidx.fragment.app.FragmentContainerView

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -38,13 +38,14 @@
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/btn_upload_music"
             android:layout_width="match_parent"
-            android:layout_height="250dp"
+            android:layout_height="155dp"
+            android:layout_marginTop="20dp"
             android:background="@color/primary"
             android:paddingHorizontal="25dp"
-            android:paddingVertical="30dp"
+            android:paddingVertical="20dp"
             android:src="@drawable/ic_plus"
             android:tint="@color/white"
-            app:contentPadding="70dp"
+            app:contentPadding="40dp"
             app:layout_constraintTop_toBottomOf="@id/abl_sub"
             app:shapeAppearance="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
 

--- a/app/src/main/res/layout/activity_music_register.xml
+++ b/app/src/main/res/layout/activity_music_register.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_ai_album_select.xml
+++ b/app/src/main/res/layout/fragment_ai_album_select.xml
@@ -1,9 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.register.music.ai.AIAlbumSelectFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.register.music.ai.AIAlbumSelectFragment">
+
+        <TextView
+            android:id="@+id/tv_choose"
+            style="@style/title.small"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:layout_marginTop="20dp"
+            android:text="Choose"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginHorizontal="15dp"
+            app:dividerColor="@color/black"
+            app:layout_constraintBottom_toBottomOf="@id/tv_choose"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_choose"
+            app:layout_constraintTop_toTopOf="@id/tv_choose" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="15dp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_choose"
+            app:spanCount="3"
+            tools:itemCount="9"
+            tools:listitem="@layout/item_ai_image" />
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_register"
+            android:layout_width="230dp"
+            android:layout_height="60dp"
+            android:layout_marginBottom="50dp"
+            android:clickable="true"
+            android:focusable="true"
+            app:cardBackgroundColor="@color/primary"
+            app:cardCornerRadius="100dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/tv_register"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/register"
+                android:textAppearance="@style/button.bold" />
+
+        </androidx.cardview.widget.CardView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_ai_album_select.xml
+++ b/app/src/main/res/layout/fragment_ai_album_select.xml
@@ -49,28 +49,20 @@
             tools:itemCount="9"
             tools:listitem="@layout/item_ai_image" />
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/cv_register"
+        <TextView
+            android:id="@+id/btn_register"
             android:layout_width="230dp"
             android:layout_height="60dp"
             android:layout_marginBottom="50dp"
+            android:background="@drawable/bg_button_selector"
             android:clickable="true"
             android:focusable="true"
-            app:cardBackgroundColor="@color/primary"
-            app:cardCornerRadius="100dp"
+            android:gravity="center"
+            android:text="@string/register"
+            android:textAppearance="@style/button.bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
-
-            <TextView
-                android:id="@+id/tv_register"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/register"
-                android:textAppearance="@style/button.bold" />
-
-        </androidx.cardview.widget.CardView>
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_ai_album_select.xml
+++ b/app/src/main/res/layout/fragment_ai_album_select.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.register.music.ai.AIAlbumSelectFragment">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_ai_album_select.xml
+++ b/app/src/main/res/layout/fragment_ai_album_select.xml
@@ -37,6 +37,7 @@
             app:layout_constraintTop_toTopOf="@id/tv_choose" />
 
         <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_ai_image"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"

--- a/app/src/main/res/layout/fragment_ai_album_select.xml
+++ b/app/src/main/res/layout/fragment_ai_album_select.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_album.xml
+++ b/app/src/main/res/layout/fragment_album.xml
@@ -55,6 +55,7 @@
                 android:background="@color/white"
                 android:clickable="true"
                 android:focusable="true"
+                android:onClick="@{(view) -> viewModel.onClickButton(view)}"
                 android:src="@drawable/ic_plus"
                 android:visibility="visible"
                 app:contentPadding="8dp"

--- a/app/src/main/res/layout/fragment_music_upload.xml
+++ b/app/src/main/res/layout/fragment_music_upload.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.register.music.upload.MusicUploadFragment">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_music_upload.xml
+++ b/app/src/main/res/layout/fragment_music_upload.xml
@@ -22,6 +22,7 @@
             android:layout_marginHorizontal="30dp"
             android:orientation="vertical"
             android:paddingHorizontal="5dp"
+            android:layout_marginTop="15dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <EditText

--- a/app/src/main/res/layout/fragment_music_upload.xml
+++ b/app/src/main/res/layout/fragment_music_upload.xml
@@ -80,7 +80,6 @@
         </LinearLayout>
 
         <androidx.cardview.widget.CardView
-            android:id="@+id/btn_upload_music"
             android:layout_width="match_parent"
             android:layout_height="100dp"
             android:layout_marginHorizontal="25dp"
@@ -104,28 +103,20 @@
                 android:textAppearance="@style/description.small" />
         </androidx.cardview.widget.CardView>
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/cv_register"
+        <TextView
+            android:id="@+id/btn_register"
             android:layout_width="230dp"
             android:layout_height="60dp"
             android:layout_marginBottom="50dp"
+            android:background="@drawable/bg_button_selector"
             android:clickable="true"
             android:focusable="true"
-            app:cardBackgroundColor="@color/primary"
-            app:cardCornerRadius="100dp"
+            android:gravity="center"
+            android:text="@string/register"
+            android:textAppearance="@style/button.bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
-
-            <TextView
-                android:id="@+id/tv_register"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/register"
-                android:textAppearance="@style/button.bold" />
-
-        </androidx.cardview.widget.CardView>
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_music_upload.xml
+++ b/app/src/main/res/layout/fragment_music_upload.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.capstone.artwhale.presentation.register.music.MusicRegisterViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -97,6 +100,7 @@
                 android:gravity="top"
                 android:hint="@string/input_lyrics"
                 android:inputType="text"
+                android:text="@={viewModel.content}"
                 android:textAppearance="@style/description.small" />
         </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/fragment_music_upload.xml
+++ b/app/src/main/res/layout/fragment_music_upload.xml
@@ -1,9 +1,127 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.register.music.upload.MusicUploadFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.register.music.upload.MusicUploadFragment">
+
+        <LinearLayout
+            android:id="@+id/ll_album_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="30dp"
+            android:orientation="vertical"
+            android:paddingHorizontal="5dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <EditText
+                android:id="@+id/et_album_title"
+                style="@style/title.small"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:autofillHints="@null"
+                android:background="@android:color/transparent"
+                android:hint="@string/input_title"
+                android:inputType="textMultiLine|textNoSuggestions"
+                android:maxLines="1"
+                android:paddingHorizontal="15dp"
+                android:paddingVertical="5dp"
+                android:text="@={viewModel.title}"
+                android:textColorHint="@color/gray40" />
+
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="0.7dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_magnifier"
+                app:dividerColor="@color/gray40"
+                app:tint="@color/white" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ll_spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="30dp"
+            android:layout_marginTop="20dp"
+            android:orientation="vertical"
+            android:paddingHorizontal="5dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ll_album_title">
+
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/spinner"
+                style="@style/title.small"
+                android:layout_width="130dp"
+                android:layout_height="0dp"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:textColorHint="@color/gray" />
+
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="0.7dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_magnifier"
+                app:dividerColor="@color/gray40" />
+        </LinearLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/btn_upload_music"
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:layout_marginHorizontal="25dp"
+            android:layout_marginVertical="30dp"
+            android:background="@color/primary"
+            android:tint="@color/white"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="12dp"
+            app:contentPadding="10dp"
+            app:layout_constraintTop_toBottomOf="@id/ll_spinner">
+
+            <EditText
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:autofillHints="@null"
+                android:background="@android:color/transparent"
+                android:gravity="top"
+                android:hint="@string/input_lyrics"
+                android:inputType="text"
+                android:textAppearance="@style/description.small" />
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_register"
+            android:layout_width="230dp"
+            android:layout_height="60dp"
+            android:layout_marginBottom="50dp"
+            android:clickable="true"
+            android:focusable="true"
+            app:cardBackgroundColor="@color/primary"
+            app:cardCornerRadius="100dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/tv_register"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/register"
+                android:textAppearance="@style/button.bold" />
+
+        </androidx.cardview.widget.CardView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_ai_image.xml
+++ b/app/src/main/res/layout/item_ai_image.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="url"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            image="@{url}"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/black"
+            android:padding="15dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/ShapeAppearanceOverlay.App.CornerSize10Percent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -13,8 +13,8 @@
         tools:layout="@layout/fragment_music">
 
         <action
-            android:id="@+id/action_FirstFragment_to_SecondFragment"
-            app:destination="@id/albumFragment" />
+            android:id="@+id/action_to_SearchFragment"
+            app:destination="@id/searchFragment" />
     </fragment>
     <fragment
         android:id="@+id/albumFragment"

--- a/app/src/main/res/navigation/nav_music_register_graph.xml
+++ b/app/src/main/res/navigation/nav_music_register_graph.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_profile_graph"
+    app:startDestination="@id/musicUploadFragment">
+
+    <fragment
+        android:id="@+id/musicUploadFragment"
+        android:name="com.capstone.artwhale.presentation.register.music.upload.MusicUploadFragment"
+        android:label="@string/fragment_music"
+        tools:layout="@layout/fragment_music_upload">
+
+        <action
+            android:id="@+id/action_to_ai_album_select"
+            app:destination="@id/aIAlbumSelectFragment"
+            app:enterAnim="@android:anim/fade_in"
+            app:exitAnim="@android:anim/fade_out" />
+    </fragment>
+    <fragment
+        android:id="@+id/aIAlbumSelectFragment"
+        android:name="com.capstone.artwhale.presentation.register.music.ai.AIAlbumSelectFragment"
+        android:label="@string/fragment_album"
+        tools:layout="@layout/fragment_ai_album_select">
+
+        <action
+            android:id="@+id/action_music_upload"
+            app:destination="@id/musicUploadFragment"
+            app:enterAnim="@android:anim/fade_in"
+            app:exitAnim="@android:anim/fade_out" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/navigation/nav_music_register_graph.xml
+++ b/app/src/main/res/navigation/nav_music_register_graph.xml
@@ -9,6 +9,7 @@
         android:id="@+id/musicUploadFragment"
         android:name="com.capstone.artwhale.presentation.register.music.upload.MusicUploadFragment"
         android:label="@string/fragment_music"
+        android:tag="@string/activity_music_register"
         tools:layout="@layout/fragment_music_upload">
 
         <action

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,6 @@
     <string name="like_album">좋아요 표시한 앨범</string>
     <string name="like_music">좋아요 표시한 음악</string>
     <string name="all_list">전체보기</string>
+    <string name="activity_music_register">Music Art</string>
+    <string name="activity_album_register">Album Art</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,6 @@
     <string name="all_list">전체보기</string>
     <string name="activity_music_register">Music Art</string>
     <string name="activity_album_register">Album Art</string>
+    <string name="input_title">제목을 입력하세요</string>
+    <string name="register">Register</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,5 @@
     <string name="activity_album_register">Album Art</string>
     <string name="input_title">제목을 입력하세요</string>
     <string name="register">Register</string>
+    <string name="input_lyrics">가사를 입력하세요</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -42,6 +42,10 @@
         <item name="android:textColor">@color/white</item>
     </style>
 
+    <style name="button.bold" parent="button">
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="button.social_login" parent="button">
         <item name="android:textSize">16sp</item>
         <item name="android:textStyle">bold</item>


### PR DESCRIPTION
### ❗️ 이슈
- close #37 
- close #38

### 📝 구현한 내용
- Album
  - 이미지 로드하기
  - 스피너 등록 - 감정 리스트 받아오기
  - 각 버튼 기능 구현
  - Album Register 화면 구현
- Music
  - 음원 로컬에서 로드하기
    - 로드 후 미니플레이어 보여주기
    - 로드 후 버튼 활성화
  - 각 버튼 기능 구현
  - ai 모드인지 체크 후 전체 UI 변경
  - 스피너 등록 - 감정 리스트 받아오기
  - Music Register 화면 구현하기
  - Music Register - AI & Normal 버전 화면 구현하기
  - Music Register - Image List 화면 구현하기
  - Music Register Mini Player 화면 구현하기