### PR TITLE
feat: 유저 Profile Network 적용

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -64,7 +64,7 @@
         <entry key="app/src/main/res/layout/fragment_music_player.xml" value="0.3879598662207358" />
         <entry key="app/src/main/res/layout/fragment_music_upload.xml" value="0.36252543131510423" />
         <entry key="app/src/main/res/layout/fragment_my_art.xml" value="0.16666666666666666" />
-        <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.17916666666666667" />
+        <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.31745554606119797" />
         <entry key="app/src/main/res/layout/fragment_search.xml" value="0.29575958251953116" />
         <entry key="app/src/main/res/layout/fragment_second.xml" value="0.2671875" />
         <entry key="app/src/main/res/layout/fragment_setting.xml" value="0.19270833333333334" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,4 +94,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
+
+    //File Util
+    implementation "commons-io:commons-io:$common_version"
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSource.kt
@@ -1,4 +1,9 @@
 package com.capstone.artwhale.data.datasource.album
 
+import com.capstone.artwhale.domain.model.Album
+
 interface AlbumDataSource {
+
+    suspend fun getMyAlbumList(): List<Album>
+    suspend fun getLikeAlbumList(): List<Album>
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSource.kt
@@ -1,9 +1,11 @@
 package com.capstone.artwhale.data.datasource.album
 
+import com.capstone.artwhale.data.dto.UpdateLikeDto
 import com.capstone.artwhale.domain.model.Album
 
 interface AlbumDataSource {
 
     suspend fun getMyAlbumList(): List<Album>
     suspend fun getLikeAlbumList(): List<Album>
+    suspend fun updateLikeAlbum(updateLikeDto: UpdateLikeDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.capstone.artwhale.data.datasource.album
 
+import com.capstone.artwhale.data.dto.UpdateLikeDto
 import com.capstone.artwhale.data.service.AlbumService
 import com.capstone.artwhale.domain.model.Album
 import javax.inject.Inject
@@ -10,4 +11,6 @@ class AlbumDataSourceImpl @Inject constructor(
 
     override suspend fun getMyAlbumList(): List<Album> = albumService.getMyAlbumList()
     override suspend fun getLikeAlbumList(): List<Album> = albumService.getLikeAlbumList()
+    override suspend fun updateLikeAlbum(updateLikeDto: UpdateLikeDto) =
+        albumService.updateLikeAlbum(updateLikeDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/album/AlbumDataSourceImpl.kt
@@ -1,8 +1,13 @@
 package com.capstone.artwhale.data.datasource.album
 
 import com.capstone.artwhale.data.service.AlbumService
+import com.capstone.artwhale.domain.model.Album
 import javax.inject.Inject
 
 class AlbumDataSourceImpl @Inject constructor(
     private val albumService: AlbumService
-) : AlbumDataSource {}
+) : AlbumDataSource {
+
+    override suspend fun getMyAlbumList(): List<Album> = albumService.getMyAlbumList()
+    override suspend fun getLikeAlbumList(): List<Album> = albumService.getLikeAlbumList()
+}

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSource.kt
@@ -1,9 +1,11 @@
 package com.capstone.artwhale.data.datasource.music
 
+import com.capstone.artwhale.data.dto.UpdateLikeDto
 import com.capstone.artwhale.domain.model.Music
 
 interface MusicDataSource {
 
     suspend fun getMyMusicList(): List<Music>
     suspend fun getLikeMusicList(): List<Music>
+    suspend fun updateLikeMusic(updateLikeDto: UpdateLikeDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSource.kt
@@ -1,4 +1,9 @@
 package com.capstone.artwhale.data.datasource.music
 
+import com.capstone.artwhale.domain.model.Music
+
 interface MusicDataSource {
+
+    suspend fun getMyMusicList(): List<Music>
+    suspend fun getLikeMusicList(): List<Music>
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.capstone.artwhale.data.datasource.music
 
+import com.capstone.artwhale.data.dto.UpdateLikeDto
 import com.capstone.artwhale.data.service.MusicService
 import com.capstone.artwhale.domain.model.Music
 import javax.inject.Inject
@@ -10,4 +11,6 @@ class MusicDataSourceImpl @Inject constructor(
 
     override suspend fun getMyMusicList(): List<Music> = musicService.getMyMusicList()
     override suspend fun getLikeMusicList(): List<Music> = musicService.getLikeMusicList()
+    override suspend fun updateLikeMusic(updateLikeDto: UpdateLikeDto) =
+        musicService.updateLikeMusic(updateLikeDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/music/MusicDataSourceImpl.kt
@@ -1,9 +1,13 @@
 package com.capstone.artwhale.data.datasource.music
 
 import com.capstone.artwhale.data.service.MusicService
+import com.capstone.artwhale.domain.model.Music
 import javax.inject.Inject
 
 class MusicDataSourceImpl @Inject constructor(
     private val musicService: MusicService
 ) : MusicDataSource {
+
+    override suspend fun getMyMusicList(): List<Music> = musicService.getMyMusicList()
+    override suspend fun getLikeMusicList(): List<Music> = musicService.getLikeMusicList()
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSource.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.data.datasource.user
+
+import com.capstone.artwhale.data.dto.UserDto
+
+interface UserDataSource {
+
+    suspend fun getMyInfo(): UserDto
+}

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSource.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSource.kt
@@ -1,8 +1,12 @@
 package com.capstone.artwhale.data.datasource.user
 
+import com.capstone.artwhale.data.dto.UpdateNickNameDto
 import com.capstone.artwhale.data.dto.UserDto
+import java.io.File
 
 interface UserDataSource {
 
     suspend fun getMyInfo(): UserDto
+    suspend fun updateProfileImage(key: String, image: File)
+    suspend fun updateNickName(nickName: UpdateNickNameDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSourceImpl.kt
@@ -1,7 +1,12 @@
 package com.capstone.artwhale.data.datasource.user
 
+import com.capstone.artwhale.data.dto.UpdateNickNameDto
 import com.capstone.artwhale.data.dto.UserDto
 import com.capstone.artwhale.data.service.UserService
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
 import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(
@@ -9,4 +14,17 @@ class UserDataSourceImpl @Inject constructor(
 ) : UserDataSource {
 
     override suspend fun getMyInfo(): UserDto = userService.getMyInfo()
+
+    override suspend fun updateNickName(nickName: UpdateNickNameDto) =
+        userService.updateNickName(nickName)
+
+    override suspend fun updateProfileImage(key: String, image: File) {
+        userService.updateProfileImage(
+            MultipartBody.Part.createFormData(
+                key,
+                image.name,
+                image.asRequestBody("image/*".toMediaTypeOrNull())
+            )
+        )
+    }
 }

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSourceImpl.kt
@@ -1,0 +1,12 @@
+package com.capstone.artwhale.data.datasource.user
+
+import com.capstone.artwhale.data.dto.UserDto
+import com.capstone.artwhale.data.service.UserService
+import javax.inject.Inject
+
+class UserDataSourceImpl @Inject constructor(
+    private val userService: UserService
+) : UserDataSource {
+
+    override suspend fun getMyInfo(): UserDto = userService.getMyInfo()
+}

--- a/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/datasource/user/UserDataSourceImpl.kt
@@ -19,12 +19,15 @@ class UserDataSourceImpl @Inject constructor(
         userService.updateNickName(nickName)
 
     override suspend fun updateProfileImage(key: String, image: File) {
-        userService.updateProfileImage(
-            MultipartBody.Part.createFormData(
-                key,
-                image.name,
-                image.asRequestBody("image/*".toMediaTypeOrNull())
+        if (image.extension == "jpg" || image.extension == "jpeg" || image.extension == "png") {
+            val type = "image/" + image.extension
+            userService.updateProfileImage(
+                MultipartBody.Part.createFormData(
+                    key,
+                    image.name,
+                    image.asRequestBody(type.toMediaTypeOrNull())
+                )
             )
-        )
+        }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/data/dto/FileDto.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/dto/FileDto.kt
@@ -1,0 +1,21 @@
+package com.capstone.artwhale.data.dto
+
+
+import com.google.gson.annotations.SerializedName
+
+data class FileDto(
+    @SerializedName("createdAt")
+    val createdAt: String,
+    @SerializedName("fileType")
+    val fileType: String,
+    @SerializedName("id")
+    val id: Int,
+    @SerializedName("originalName")
+    val originalName: String,
+    @SerializedName("path")
+    val path: String,
+    @SerializedName("size")
+    val size: Int,
+    @SerializedName("updatedAt")
+    val updatedAt: String
+)

--- a/app/src/main/java/com/capstone/artwhale/data/dto/UpdateLikeDto.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/dto/UpdateLikeDto.kt
@@ -1,0 +1,10 @@
+package com.capstone.artwhale.data.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateLikeDto(
+    @SerializedName("id")
+    val id: Int
+)
+
+fun Int.toUpdateLikeDto() = UpdateLikeDto(this)

--- a/app/src/main/java/com/capstone/artwhale/data/dto/UpdateNickNameDto.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/dto/UpdateNickNameDto.kt
@@ -1,0 +1,10 @@
+package com.capstone.artwhale.data.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateNickNameDto(
+    @SerializedName("nickname")
+    val nickname: String
+)
+
+fun String.toUpdateNicknameDto() = UpdateNickNameDto(this)

--- a/app/src/main/java/com/capstone/artwhale/data/dto/UserDto.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/dto/UserDto.kt
@@ -1,6 +1,7 @@
 package com.capstone.artwhale.data.dto
 
 
+import com.capstone.artwhale.BuildConfig.BASE_URL
 import com.capstone.artwhale.domain.model.UserInfo
 import com.google.gson.annotations.SerializedName
 
@@ -10,7 +11,7 @@ data class UserDto(
     @SerializedName("email")
     val email: String,
     @SerializedName("fileId")
-    val fileId: Any,
+    val fileId: FileDto?,
     @SerializedName("id")
     val id: Int,
     @SerializedName("nickname")
@@ -23,6 +24,6 @@ data class UserDto(
     fun toUserInfo(): UserInfo = UserInfo(
         email = email,
         name = nickname,
-        profileImgUrl = profileImgUrl
+        profileImgUrl = if (fileId == null) null else BASE_URL + fileId.path
     )
 }

--- a/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
@@ -13,30 +13,35 @@ class AlbumRepositoryImpl @Inject constructor(
     override suspend fun getAlbumRanking(): List<Album> {
         return listOf(
             Album(
+                0,
                 "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
                 "dream",
                 "케이시",
                 false
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
                 "Medicine",
                 "New Hope Club",
                 true
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
                 "Bonfire",
                 "Peder Elias",
                 false
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
                 "하루하루",
                 "Bigbang",
                 true
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
                 "Talk",
                 "Why don't we",
@@ -48,30 +53,35 @@ class AlbumRepositoryImpl @Inject constructor(
     override suspend fun getAllAlbum(): List<Album> {
         return listOf(
             Album(
+                0,
                 "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
                 "dream",
                 "케이시",
                 false
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
                 "Medicine",
                 "New Hope Club",
                 true
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
                 "Bonfire",
                 "Peder Elias",
                 false
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
                 "하루하루",
                 "Bigbang",
                 true
             ),
             Album(
+                0,
                 "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
                 "Talk",
                 "Why don't we",

--- a/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.capstone.artwhale.data.repository
 
 import com.capstone.artwhale.data.datasource.album.AlbumDataSource
+import com.capstone.artwhale.data.dto.toUpdateLikeDto
 import com.capstone.artwhale.domain.model.Album
 import com.capstone.artwhale.domain.repository.AlbumRepository
 import javax.inject.Inject
@@ -96,4 +97,7 @@ class AlbumRepositoryImpl @Inject constructor(
             "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
         )
     }
+
+    override suspend fun updateLikeAlbum(id: Int) =
+        albumDataSource.updateLikeAlbum(id.toUpdateLikeDto())
 }

--- a/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/AlbumRepositoryImpl.kt
@@ -79,75 +79,9 @@ class AlbumRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getMyAlbumList(): List<Album> {
-        return listOf(
-            Album(
-                "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
-                "dream",
-                "케이시",
-                false
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
-                "Medicine",
-                "New Hope Club",
-                true
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
-                "Bonfire",
-                "Peder Elias",
-                false
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
-                "하루하루",
-                "Bigbang",
-                true
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
-                "Talk",
-                "Why don't we",
-                false
-            ),
-        )
-    }
+    override suspend fun getMyAlbumList(): List<Album> = albumDataSource.getMyAlbumList()
 
-    override suspend fun getLikeAlbumList(): List<Album> {
-        return listOf(
-            Album(
-                "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
-                "dream",
-                "케이시",
-                false
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
-                "Medicine",
-                "New Hope Club",
-                true
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
-                "Bonfire",
-                "Peder Elias",
-                false
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
-                "하루하루",
-                "Bigbang",
-                true
-            ),
-            Album(
-                "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
-                "Talk",
-                "Why don't we",
-                false
-            ),
-        )
-    }
+    override suspend fun getLikeAlbumList(): List<Album> = albumDataSource.getLikeAlbumList()
 
     override suspend fun getAiAlbumImageList(): List<String> {
         return listOf(

--- a/app/src/main/java/com/capstone/artwhale/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/MusicRepositoryImpl.kt
@@ -13,6 +13,7 @@ class MusicRepositoryImpl @Inject constructor(
     override suspend fun getMusicChart(): List<Music> {
         return listOf(
             Music(
+                0,
                 "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
                 "dream",
                 "케이시",
@@ -20,6 +21,7 @@ class MusicRepositoryImpl @Inject constructor(
                 false
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
                 "Medicine",
                 "New Hope Club",
@@ -27,6 +29,7 @@ class MusicRepositoryImpl @Inject constructor(
                 true
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
                 "Bonfire",
                 "Peder Elias",
@@ -34,6 +37,7 @@ class MusicRepositoryImpl @Inject constructor(
                 false
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
                 "하루하루",
                 "Bigbang",
@@ -41,6 +45,7 @@ class MusicRepositoryImpl @Inject constructor(
                 true
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
                 "Talk",
                 "Why don't we",
@@ -53,6 +58,7 @@ class MusicRepositoryImpl @Inject constructor(
     override suspend fun getNewMusics(): List<Music> {
         return listOf(
             Music(
+                0,
                 "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
                 "dream",
                 "케이시",
@@ -60,6 +66,7 @@ class MusicRepositoryImpl @Inject constructor(
                 false
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
                 "Medicine",
                 "New Hope Club",
@@ -67,6 +74,7 @@ class MusicRepositoryImpl @Inject constructor(
                 true
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
                 "Bonfire",
                 "Peder Elias",
@@ -74,6 +82,7 @@ class MusicRepositoryImpl @Inject constructor(
                 false
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
                 "하루하루",
                 "Bigbang",
@@ -81,6 +90,7 @@ class MusicRepositoryImpl @Inject constructor(
                 true
             ),
             Music(
+                0,
                 "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
                 "Talk",
                 "Why don't we",

--- a/app/src/main/java/com/capstone/artwhale/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/MusicRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.capstone.artwhale.data.repository
 
 import com.capstone.artwhale.data.datasource.music.MusicDataSource
+import com.capstone.artwhale.data.dto.toUpdateLikeDto
 import com.capstone.artwhale.domain.model.Music
 import com.capstone.artwhale.domain.repository.MusicRepository
 import javax.inject.Inject
@@ -94,4 +95,7 @@ class MusicRepositoryImpl @Inject constructor(
 
     override suspend fun getLikeMusicList(): List<Music> =
         musicDataSource.getLikeMusicList()
+
+    override suspend fun updateLikeMusic(id: Int) =
+        musicDataSource.updateLikeMusic(id.toUpdateLikeDto())
 }

--- a/app/src/main/java/com/capstone/artwhale/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/MusicRepositoryImpl.kt
@@ -89,83 +89,9 @@ class MusicRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getMyMusicList(): List<Music> {
-        return listOf(
-            Music(
-                "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
-                "dream",
-                "케이시",
-                3 * 60 * 1000,
-                false
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
-                "Medicine",
-                "New Hope Club",
-                3 * 60 * 1000,
-                true
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
-                "Bonfire",
-                "Peder Elias",
-                3 * 60 * 1000,
-                false
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
-                "하루하루",
-                "Bigbang",
-                3 * 60 * 1000,
-                true
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
-                "Talk",
-                "Why don't we",
-                3 * 60 * 1000,
-                false
-            ),
-        )
-    }
+    override suspend fun getMyMusicList(): List<Music> =
+        musicDataSource.getMyMusicList()
 
-    override suspend fun getLikeMusicList(): List<Music> {
-        return listOf(
-            Music(
-                "https://lh3.googleusercontent.com/mJl1ApC-4mnQGVml2yXhDnNntFj-lxWtka7-N5o_Ioa-VDHD5WZFC_2g7cdzOgOuZNLH_1QNMzRSbLTB=w544-h544-l90-rj",
-                "dream",
-                "케이시",
-                3 * 60 * 1000,
-                false
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/77GRI8SOJ6K6HyiGcRkRrj1rGO_ESNfpUm1Nk8phTDAI2KevWd8yQaEwZ2PkDyOaSSI5HcPg9HTlVgHWbw=w544-h544-l90-rj",
-                "Medicine",
-                "New Hope Club",
-                3 * 60 * 1000,
-                true
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/Zb68_2VA8BTzSHyxDIgQu8hJTZri8PrEGQPORYhG90UIkR02wgVMJGdBvw8Tz_x-Kl7-qWN7FyOuhtw0=w544-h544-l90-rj",
-                "Bonfire",
-                "Peder Elias",
-                3 * 60 * 1000,
-                false
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/FZgtqH0qtrPtk0Vn-fQqOfPUEanelSuDfPUaiR3Z7Jb_VNKYgvLQQBtExAyqUNV78UhO20SHYG3nBzAc=w544-h544-l90-rj",
-                "하루하루",
-                "Bigbang",
-                3 * 60 * 1000,
-                true
-            ),
-            Music(
-                "https://lh3.googleusercontent.com/Eve_VljkGvgC-jwS30uaa5A4suBNQZD04mQGwmzTsPdHrAfHPntv4tKk2-aN5ltLX4uU8E7Esce7PTM=w544-h544-l90-rj",
-                "Talk",
-                "Why don't we",
-                3 * 60 * 1000,
-                false
-            ),
-        )
-    }
+    override suspend fun getLikeMusicList(): List<Music> =
+        musicDataSource.getLikeMusicList()
 }

--- a/app/src/main/java/com/capstone/artwhale/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.capstone.artwhale.data.repository
+
+import com.capstone.artwhale.data.datasource.user.UserDataSource
+import com.capstone.artwhale.domain.model.UserInfo
+import com.capstone.artwhale.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val userDataSource: UserDataSource
+) : UserRepository {
+
+    override suspend fun getMyInfo(): UserInfo = userDataSource.getMyInfo().toUserInfo()
+}

--- a/app/src/main/java/com/capstone/artwhale/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/UserRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package com.capstone.artwhale.data.repository
 
+import android.net.Uri
 import com.capstone.artwhale.data.datasource.user.UserDataSource
+import com.capstone.artwhale.data.dto.toUpdateNicknameDto
 import com.capstone.artwhale.domain.model.UserInfo
 import com.capstone.artwhale.domain.repository.UserRepository
+import java.io.File
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
@@ -10,4 +13,11 @@ class UserRepositoryImpl @Inject constructor(
 ) : UserRepository {
 
     override suspend fun getMyInfo(): UserInfo = userDataSource.getMyInfo().toUserInfo()
+
+    override suspend fun updateNickName(nickName: String) =
+        userDataSource.updateNickName(nickName.toUpdateNicknameDto())
+
+    override suspend fun updateProfileImage(uri: String) {
+        Uri.parse(uri).path?.let { userDataSource.updateProfileImage("image", File(it)) }
+    }
 }

--- a/app/src/main/java/com/capstone/artwhale/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/repository/UserRepositoryImpl.kt
@@ -1,14 +1,15 @@
 package com.capstone.artwhale.data.repository
 
-import android.net.Uri
 import com.capstone.artwhale.data.datasource.user.UserDataSource
 import com.capstone.artwhale.data.dto.toUpdateNicknameDto
 import com.capstone.artwhale.domain.model.UserInfo
 import com.capstone.artwhale.domain.repository.UserRepository
+import com.capstone.artwhale.util.LocalPathUtil
 import java.io.File
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
+    private val localPathUtil: LocalPathUtil,
     private val userDataSource: UserDataSource
 ) : UserRepository {
 
@@ -18,6 +19,7 @@ class UserRepositoryImpl @Inject constructor(
         userDataSource.updateNickName(nickName.toUpdateNicknameDto())
 
     override suspend fun updateProfileImage(uri: String) {
-        Uri.parse(uri).path?.let { userDataSource.updateProfileImage("image", File(it)) }
+        localPathUtil.getRealPathFromUriString(uri)
+            ?.let { userDataSource.updateProfileImage("image", File(it)) }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/data/service/AlbumService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/AlbumService.kt
@@ -1,7 +1,10 @@
 package com.capstone.artwhale.data.service
 
+import com.capstone.artwhale.data.dto.UpdateLikeDto
 import com.capstone.artwhale.domain.model.Album
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface AlbumService {
 
@@ -10,4 +13,7 @@ interface AlbumService {
 
     @GET("/api/album-art/like")
     suspend fun getLikeAlbumList(): List<Album>
+
+    @PATCH("/api/album-art/like")
+    suspend fun updateLikeAlbum(@Body updateLikeDto: UpdateLikeDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/service/AlbumService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/AlbumService.kt
@@ -1,3 +1,13 @@
 package com.capstone.artwhale.data.service
 
-interface AlbumService {}
+import com.capstone.artwhale.domain.model.Album
+import retrofit2.http.GET
+
+interface AlbumService {
+
+    @GET("/api/album-art/my")
+    suspend fun getMyAlbumList(): List<Album>
+
+    @GET("/api/album-art/like")
+    suspend fun getLikeAlbumList(): List<Album>
+}

--- a/app/src/main/java/com/capstone/artwhale/data/service/MusicService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/MusicService.kt
@@ -1,7 +1,10 @@
 package com.capstone.artwhale.data.service
 
+import com.capstone.artwhale.data.dto.UpdateLikeDto
 import com.capstone.artwhale.domain.model.Music
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface MusicService {
 
@@ -10,4 +13,7 @@ interface MusicService {
 
     @GET("/api/music/like")
     suspend fun getLikeMusicList(): List<Music>
+
+    @PATCH("/api/music/like")
+    suspend fun updateLikeMusic(@Body updateLikeDto: UpdateLikeDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/service/MusicService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/MusicService.kt
@@ -1,3 +1,13 @@
 package com.capstone.artwhale.data.service
 
-interface MusicService {}
+import com.capstone.artwhale.domain.model.Music
+import retrofit2.http.GET
+
+interface MusicService {
+
+    @GET("/api/music/my")
+    suspend fun getMyMusicList(): List<Music>
+
+    @GET("/api/music/like")
+    suspend fun getLikeMusicList(): List<Music>
+}

--- a/app/src/main/java/com/capstone/artwhale/data/service/UserService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/UserService.kt
@@ -1,10 +1,19 @@
 package com.capstone.artwhale.data.service
 
+import com.capstone.artwhale.data.dto.UpdateNickNameDto
 import com.capstone.artwhale.data.dto.UserDto
-import retrofit2.http.GET
+import okhttp3.MultipartBody
+import retrofit2.http.*
 
 interface UserService {
 
     @GET("/api/user/info")
     suspend fun getMyInfo(): UserDto
+
+    @Multipart
+    @PATCH("/api/user/image")
+    suspend fun updateProfileImage(@Part image: MultipartBody.Part)
+
+    @PATCH("/api/user/nickname")
+    suspend fun updateNickName(@Body nickName: UpdateNickNameDto)
 }

--- a/app/src/main/java/com/capstone/artwhale/data/service/UserService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/UserService.kt
@@ -1,0 +1,10 @@
+package com.capstone.artwhale.data.service
+
+import com.capstone.artwhale.data.dto.UserDto
+import retrofit2.http.POST
+
+interface UserService {
+
+    @POST("/api/user/info")
+    suspend fun getMyInfo(): UserDto
+}

--- a/app/src/main/java/com/capstone/artwhale/data/service/UserService.kt
+++ b/app/src/main/java/com/capstone/artwhale/data/service/UserService.kt
@@ -1,10 +1,10 @@
 package com.capstone.artwhale.data.service
 
 import com.capstone.artwhale.data.dto.UserDto
-import retrofit2.http.POST
+import retrofit2.http.GET
 
 interface UserService {
 
-    @POST("/api/user/info")
+    @GET("/api/user/info")
     suspend fun getMyInfo(): UserDto
 }

--- a/app/src/main/java/com/capstone/artwhale/di/DataSourceModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/DataSourceModule.kt
@@ -12,6 +12,8 @@ import com.capstone.artwhale.data.datasource.notice.NoticeDataSource
 import com.capstone.artwhale.data.datasource.notice.NoticeDataSourceImpl
 import com.capstone.artwhale.data.datasource.recent.RecentSearchDataSource
 import com.capstone.artwhale.data.datasource.recent.RecentSearchDataSourceImpl
+import com.capstone.artwhale.data.datasource.user.UserDataSource
+import com.capstone.artwhale.data.datasource.user.UserDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -57,4 +59,10 @@ abstract class DataSourceModule {
     abstract fun provideRecentSearchDataSource(
         recentSearchDataSource: RecentSearchDataSourceImpl
     ): RecentSearchDataSource
+
+    @Singleton
+    @Binds
+    abstract fun provideUserDataSource(
+        userDataSource: UserDataSourceImpl
+    ): UserDataSource
 }

--- a/app/src/main/java/com/capstone/artwhale/di/NetworkModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/NetworkModule.kt
@@ -89,4 +89,10 @@ object NetworkModule {
     fun provideMoodService(retrofit: Retrofit): MoodService {
         return retrofit.create(MoodService::class.java)
     }
+
+    @Singleton
+    @Provides
+    fun provideUserService(retrofit: Retrofit): UserService {
+        return retrofit.create(UserService::class.java)
+    }
 }

--- a/app/src/main/java/com/capstone/artwhale/di/RepositoryModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/RepositoryModule.kt
@@ -47,4 +47,10 @@ abstract class RepositoryModule {
     abstract fun provideRecentSearchRepository(
         recentSearchRepository: RecentSearchRepositoryImpl
     ): RecentSearchRepository
+
+    @Singleton
+    @Binds
+    abstract fun provideUserRepository(
+        userRepository: UserRepositoryImpl
+    ): UserRepository
 }

--- a/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
@@ -24,6 +24,8 @@ import com.capstone.artwhale.domain.usecase.recent.InsertRecentSearchUseCase
 import com.capstone.artwhale.domain.usecase.recent.impl.DeleteRecentSearchUseCaseImpl
 import com.capstone.artwhale.domain.usecase.recent.impl.GetRecentSearchUseCaseImpl
 import com.capstone.artwhale.domain.usecase.recent.impl.InsertRecentSearchUseCaseImpl
+import com.capstone.artwhale.domain.usecase.user.GetMyInfoUseCase
+import com.capstone.artwhale.domain.usecase.user.impl.GetMyInfoUseCaseImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -96,8 +98,8 @@ abstract class UseCaseModule {
 
     @Singleton
     @Binds
-    abstract fun provideGetMyInfoUseCase(
-        getMyInfoUseCase: GetTokenInfoUseCaseImpl
+    abstract fun provideGetTokenInfoUseCase(
+        getTokenInfoUseCase: GetTokenInfoUseCaseImpl
     ): GetTokenInfoUseCase
 
     @Singleton
@@ -129,4 +131,10 @@ abstract class UseCaseModule {
     abstract fun provideDeleteRecentSearchUseCase(
         deleteRecentSearchUseCase: DeleteRecentSearchUseCaseImpl
     ): DeleteRecentSearchUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideGetMyInfoUseCase(
+        getMyInfoUseCase: GetMyInfoUseCaseImpl
+    ): GetMyInfoUseCase
 }

--- a/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
@@ -8,14 +8,8 @@ import com.capstone.artwhale.domain.usecase.auth.impl.GetTokenInfoUseCaseImpl
 import com.capstone.artwhale.domain.usecase.auth.impl.LoginUseCaseImpl
 import com.capstone.artwhale.domain.usecase.mood.GetMoodListUseCase
 import com.capstone.artwhale.domain.usecase.mood.impl.GetMoodListUseCaseImpl
-import com.capstone.artwhale.domain.usecase.music.GetLikeMusicListUseCase
-import com.capstone.artwhale.domain.usecase.music.GetMusicChartUseCase
-import com.capstone.artwhale.domain.usecase.music.GetMyMusicListUseCase
-import com.capstone.artwhale.domain.usecase.music.GetNewMusicUseCase
-import com.capstone.artwhale.domain.usecase.music.impl.GetLikeMusicListUseCaseImpl
-import com.capstone.artwhale.domain.usecase.music.impl.GetMusicChartUseCaseImpl
-import com.capstone.artwhale.domain.usecase.music.impl.GetMyMusicListUseCaseImpl
-import com.capstone.artwhale.domain.usecase.music.impl.GetNewMusicUseCaseImpl
+import com.capstone.artwhale.domain.usecase.music.*
+import com.capstone.artwhale.domain.usecase.music.impl.*
 import com.capstone.artwhale.domain.usecase.notice.GetNoticeUseCase
 import com.capstone.artwhale.domain.usecase.notice.impl.GetNoticeUseCaseImpl
 import com.capstone.artwhale.domain.usecase.recent.DeleteRecentSearchUseCase
@@ -153,4 +147,16 @@ abstract class UseCaseModule {
     abstract fun provideUpdateProfileImageUseCase(
         updateProfileImageUseCase: UpdateProfileImageUseCaseImpl
     ): UpdateProfileImageUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideUpdateLikeAlbumUseCase(
+        updateLikeAlbumUseCase: UpdateLikeAlbumUseCaseImpl
+    ): UpdateLikeAlbumUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideUpdateLikeMusicUseCase(
+        updateLikeMusicUseCase: UpdateLikeMusicUseCaseImpl
+    ): UpdateLikeMusicUseCase
 }

--- a/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/UseCaseModule.kt
@@ -25,7 +25,11 @@ import com.capstone.artwhale.domain.usecase.recent.impl.DeleteRecentSearchUseCas
 import com.capstone.artwhale.domain.usecase.recent.impl.GetRecentSearchUseCaseImpl
 import com.capstone.artwhale.domain.usecase.recent.impl.InsertRecentSearchUseCaseImpl
 import com.capstone.artwhale.domain.usecase.user.GetMyInfoUseCase
+import com.capstone.artwhale.domain.usecase.user.UpdateNickNameUseCase
+import com.capstone.artwhale.domain.usecase.user.UpdateProfileImageUseCase
 import com.capstone.artwhale.domain.usecase.user.impl.GetMyInfoUseCaseImpl
+import com.capstone.artwhale.domain.usecase.user.impl.UpdateNickNameUseCaseImpl
+import com.capstone.artwhale.domain.usecase.user.impl.UpdateProfileImageUseCaseImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -137,4 +141,16 @@ abstract class UseCaseModule {
     abstract fun provideGetMyInfoUseCase(
         getMyInfoUseCase: GetMyInfoUseCaseImpl
     ): GetMyInfoUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideUpdateNickNameUseCase(
+        updateNickNameUseCase: UpdateNickNameUseCaseImpl
+    ): UpdateNickNameUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideUpdateProfileImageUseCase(
+        updateProfileImageUseCase: UpdateProfileImageUseCaseImpl
+    ): UpdateProfileImageUseCase
 }

--- a/app/src/main/java/com/capstone/artwhale/di/UtilModule.kt
+++ b/app/src/main/java/com/capstone/artwhale/di/UtilModule.kt
@@ -1,6 +1,7 @@
 package com.capstone.artwhale.di
 
 import android.content.Context
+import com.capstone.artwhale.util.LocalPathUtil
 import com.capstone.artwhale.util.MusicPlayer
 import com.capstone.artwhale.util.SharedPreferencesManager
 import dagger.Module
@@ -24,5 +25,11 @@ object UtilModule {
     @Provides
     fun provideSharedPreferencesManager(@ApplicationContext context: Context): SharedPreferencesManager {
         return SharedPreferencesManager(context)
+    }
+
+    @Singleton
+    @Provides
+    fun provideLocalPathUtil(@ApplicationContext context: Context): LocalPathUtil {
+        return LocalPathUtil(context)
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/domain/model/Album.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/model/Album.kt
@@ -3,6 +3,7 @@ package com.capstone.artwhale.domain.model
 import java.io.Serializable
 
 data class Album(
+    val id: Int = 0,
     val albumImgUrl: String,
     val title: String,
     val mood: String,

--- a/app/src/main/java/com/capstone/artwhale/domain/model/Music.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/model/Music.kt
@@ -3,6 +3,7 @@ package com.capstone.artwhale.domain.model
 import java.io.Serializable
 
 data class Music(
+    val id: Int = 0,
     val albumImgUrl: String,
     val title: String,
     val singer: String,

--- a/app/src/main/java/com/capstone/artwhale/domain/repository/AlbumRepository.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/repository/AlbumRepository.kt
@@ -9,4 +9,5 @@ interface AlbumRepository {
     suspend fun getMyAlbumList(): List<Album>
     suspend fun getLikeAlbumList(): List<Album>
     suspend fun getAiAlbumImageList(): List<String>
+    suspend fun updateLikeAlbum(id: Int)
 }

--- a/app/src/main/java/com/capstone/artwhale/domain/repository/MusicRepository.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/repository/MusicRepository.kt
@@ -8,4 +8,5 @@ interface MusicRepository {
     suspend fun getNewMusics(): List<Music>
     suspend fun getMyMusicList(): List<Music>
     suspend fun getLikeMusicList(): List<Music>
+    suspend fun updateLikeMusic(id: Int)
 }

--- a/app/src/main/java/com/capstone/artwhale/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/repository/UserRepository.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.domain.repository
+
+import com.capstone.artwhale.domain.model.UserInfo
+
+interface UserRepository {
+
+    suspend fun getMyInfo(): UserInfo
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/repository/UserRepository.kt
@@ -5,4 +5,6 @@ import com.capstone.artwhale.domain.model.UserInfo
 interface UserRepository {
 
     suspend fun getMyInfo(): UserInfo
+    suspend fun updateProfileImage(uri: String)
+    suspend fun updateNickName(nickName: String)
 }

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/album/UpdateLikeAlbumUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/album/UpdateLikeAlbumUseCase.kt
@@ -1,0 +1,6 @@
+package com.capstone.artwhale.domain.usecase.album
+
+interface UpdateLikeAlbumUseCase {
+
+    suspend operator fun invoke(id: Int): Result<Unit>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/album/impl/UpdateLikeAlbumUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/album/impl/UpdateLikeAlbumUseCaseImpl.kt
@@ -1,0 +1,13 @@
+package com.capstone.artwhale.domain.usecase.album.impl
+
+import com.capstone.artwhale.domain.repository.AlbumRepository
+import com.capstone.artwhale.domain.usecase.album.UpdateLikeAlbumUseCase
+import javax.inject.Inject
+
+class UpdateLikeAlbumUseCaseImpl @Inject constructor(
+    private val albumRepository: AlbumRepository
+) : UpdateLikeAlbumUseCase {
+
+    override suspend fun invoke(id: Int): Result<Unit> =
+        runCatching { albumRepository.updateLikeAlbum(id) }
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/music/UpdateLikeMusicUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/music/UpdateLikeMusicUseCase.kt
@@ -1,0 +1,6 @@
+package com.capstone.artwhale.domain.usecase.music
+
+interface UpdateLikeMusicUseCase {
+
+    suspend operator fun invoke(id: Int): Result<Unit>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/music/impl/UpdateLikeMusicUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/music/impl/UpdateLikeMusicUseCaseImpl.kt
@@ -1,0 +1,13 @@
+package com.capstone.artwhale.domain.usecase.music.impl
+
+import com.capstone.artwhale.domain.repository.MusicRepository
+import com.capstone.artwhale.domain.usecase.music.UpdateLikeMusicUseCase
+import javax.inject.Inject
+
+class UpdateLikeMusicUseCaseImpl @Inject constructor(
+    private val repository: MusicRepository
+) : UpdateLikeMusicUseCase {
+
+    override suspend fun invoke(id: Int): Result<Unit> =
+        runCatching { repository.updateLikeMusic(id) }
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/user/GetMyInfoUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/user/GetMyInfoUseCase.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.domain.usecase.user
+
+import com.capstone.artwhale.domain.model.UserInfo
+
+interface GetMyInfoUseCase {
+
+    suspend operator fun invoke(): Result<UserInfo>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/user/UpdateNickNameUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/user/UpdateNickNameUseCase.kt
@@ -1,0 +1,6 @@
+package com.capstone.artwhale.domain.usecase.user
+
+interface UpdateNickNameUseCase {
+
+    suspend operator fun invoke(nickName: String): Result<Unit>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/user/UpdateProfileImageUseCase.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/user/UpdateProfileImageUseCase.kt
@@ -1,0 +1,8 @@
+package com.capstone.artwhale.domain.usecase.user
+
+import com.capstone.artwhale.domain.model.UserInfo
+
+interface UpdateProfileImageUseCase {
+
+    suspend operator fun invoke(uri: String): Result<Unit>
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/user/impl/GetMyInfoUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/user/impl/GetMyInfoUseCaseImpl.kt
@@ -1,0 +1,14 @@
+package com.capstone.artwhale.domain.usecase.user.impl
+
+import com.capstone.artwhale.domain.model.UserInfo
+import com.capstone.artwhale.domain.repository.UserRepository
+import com.capstone.artwhale.domain.usecase.user.GetMyInfoUseCase
+import javax.inject.Inject
+
+class GetMyInfoUseCaseImpl @Inject constructor(
+    private val userRepository: UserRepository
+) : GetMyInfoUseCase {
+
+    override suspend operator fun invoke(): Result<UserInfo> =
+        runCatching { userRepository.getMyInfo() }
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/user/impl/UpdateNickNameUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/user/impl/UpdateNickNameUseCaseImpl.kt
@@ -1,0 +1,13 @@
+package com.capstone.artwhale.domain.usecase.user.impl
+
+import com.capstone.artwhale.domain.repository.UserRepository
+import com.capstone.artwhale.domain.usecase.user.UpdateNickNameUseCase
+import javax.inject.Inject
+
+class UpdateNickNameUseCaseImpl @Inject constructor(
+    private val userRepository: UserRepository
+) : UpdateNickNameUseCase {
+
+    override suspend operator fun invoke(nickName: String): Result<Unit> =
+        runCatching { userRepository.updateNickName(nickName) }
+}

--- a/app/src/main/java/com/capstone/artwhale/domain/usecase/user/impl/UpdateProfileImageUseCaseImpl.kt
+++ b/app/src/main/java/com/capstone/artwhale/domain/usecase/user/impl/UpdateProfileImageUseCaseImpl.kt
@@ -1,0 +1,13 @@
+package com.capstone.artwhale.domain.usecase.user.impl
+
+import com.capstone.artwhale.domain.repository.UserRepository
+import com.capstone.artwhale.domain.usecase.user.UpdateProfileImageUseCase
+import javax.inject.Inject
+
+class UpdateProfileImageUseCaseImpl @Inject constructor(
+    private val userRepository: UserRepository
+) : UpdateProfileImageUseCase {
+
+    override suspend operator fun invoke(uri: String): Result<Unit> =
+        runCatching { userRepository.updateProfileImage(uri) }
+}

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/UserViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/UserViewModel.kt
@@ -9,8 +9,10 @@ import com.capstone.artwhale.domain.model.Music
 import com.capstone.artwhale.domain.model.UserInfo
 import com.capstone.artwhale.domain.usecase.album.GetLikeAlbumListUseCase
 import com.capstone.artwhale.domain.usecase.album.GetMyAlbumListUseCase
+import com.capstone.artwhale.domain.usecase.album.UpdateLikeAlbumUseCase
 import com.capstone.artwhale.domain.usecase.music.GetLikeMusicListUseCase
 import com.capstone.artwhale.domain.usecase.music.GetMyMusicListUseCase
+import com.capstone.artwhale.domain.usecase.music.UpdateLikeMusicUseCase
 import com.capstone.artwhale.domain.usecase.user.GetMyInfoUseCase
 import com.capstone.artwhale.domain.usecase.user.UpdateNickNameUseCase
 import com.capstone.artwhale.domain.usecase.user.UpdateProfileImageUseCase
@@ -34,6 +36,8 @@ class UserViewModel @Inject constructor(
     private val getMyInfoUseCase: GetMyInfoUseCase,
     private val updateProfileImageUseCase: UpdateProfileImageUseCase,
     private val updateNickNameUseCase: UpdateNickNameUseCase,
+    private val updateLikeMusicUseCase: UpdateLikeMusicUseCase,
+    private val updateLikeAlbumUseCase: UpdateLikeAlbumUseCase,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<NetworkState>(InitialState)
@@ -100,5 +104,13 @@ class UserViewModel @Inject constructor(
             }
             launch { updateNickNameUseCase(myInfo.value.name) }
         }
+    }
+
+    fun updateAlbumLikeState(album: Album) {
+        viewModelScope.launch(Dispatchers.IO) { updateLikeAlbumUseCase(album.id) }
+    }
+
+    fun updateMusicLikeState(music: Music) {
+        viewModelScope.launch(Dispatchers.IO) { updateLikeMusicUseCase(music.id) }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/UserViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/UserViewModel.kt
@@ -9,9 +9,9 @@ import com.capstone.artwhale.domain.model.Music
 import com.capstone.artwhale.domain.model.UserInfo
 import com.capstone.artwhale.domain.usecase.album.GetLikeAlbumListUseCase
 import com.capstone.artwhale.domain.usecase.album.GetMyAlbumListUseCase
-import com.capstone.artwhale.domain.usecase.auth.GetTokenInfoUseCase
 import com.capstone.artwhale.domain.usecase.music.GetLikeMusicListUseCase
 import com.capstone.artwhale.domain.usecase.music.GetMyMusicListUseCase
+import com.capstone.artwhale.domain.usecase.user.GetMyInfoUseCase
 import com.capstone.artwhale.presentation.common.Error
 import com.capstone.artwhale.presentation.common.InitialState
 import com.capstone.artwhale.presentation.common.NetworkState
@@ -28,7 +28,7 @@ class UserViewModel @Inject constructor(
     private val getMyAlbumListUseCase: GetMyAlbumListUseCase,
     private val getLikeMusicListUseCase: GetLikeMusicListUseCase,
     private val getLikeAlbumListUseCase: GetLikeAlbumListUseCase,
-    private val getMyInfoUseCase: GetTokenInfoUseCase,
+    private val getMyInfoUseCase: GetMyInfoUseCase,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<NetworkState>(InitialState)
@@ -68,8 +68,8 @@ class UserViewModel @Inject constructor(
                     .onFailure { _state.emit(Error(it.message)) }
             }
             launch {
-                /*getMyInfoUseCase().onSuccess { _myInfo.emit(it) }
-                    .onFailure { _state.emit(Error(it.message)) }*/
+                getMyInfoUseCase().onSuccess { _myInfo.emit(it) }
+                    .onFailure { _state.emit(Error(it.message)) }
             }
         }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/UserViewModel.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/UserViewModel.kt
@@ -84,4 +84,9 @@ class UserViewModel @Inject constructor(
     fun onClickButton(view: View?) {
         viewModelScope.launch { _clickListener.emit(view?.id) }
     }
+
+    fun updateProfileInfo() {
+        viewModelScope.launch(Dispatchers.IO) {
+        }
+    }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/album/AlbumFragment.kt
@@ -2,6 +2,7 @@ package com.capstone.artwhale.presentation.home.album
 
 import android.content.Intent
 import android.os.Build
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.PagerSnapHelper
@@ -9,6 +10,7 @@ import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentAlbumBinding
 import com.capstone.artwhale.domain.model.Album
 import com.capstone.artwhale.presentation.common.BaseFragment
+import com.capstone.artwhale.presentation.home.UserViewModel
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRankingThumbnailRVAdapter
 import com.capstone.artwhale.presentation.register.album.AlbumRegisterActivity
@@ -21,6 +23,7 @@ import kotlinx.coroutines.flow.onEach
 class AlbumFragment : BaseFragment<FragmentAlbumBinding>(FragmentAlbumBinding::inflate) {
 
     private val viewModel by viewModels<AlbumViewModel>()
+    private val userViewModel by activityViewModels<UserViewModel>()
 
     private lateinit var albumRankingThumbnailRVAdapter: AlbumRankingThumbnailRVAdapter
     private lateinit var albumRVAdapter: AlbumRVAdapter
@@ -60,7 +63,11 @@ class AlbumFragment : BaseFragment<FragmentAlbumBinding>(FragmentAlbumBinding::i
     private fun initRecyclerView() {
         albumRankingThumbnailRVAdapter = AlbumRankingThumbnailRVAdapter()
         albumRVAdapter = AlbumRVAdapter()
-            .apply { setCallBack { registerMusicWithAlbum(it) } }
+            .apply {
+                setCallBack(
+                    { registerMusicWithAlbum(it) },
+                    { userViewModel.updateAlbumLikeState(it) })
+            }
 
         with(binding) {
             rvAlbumThumbnail.layoutParams.width = resources.displayMetrics.widthPixels

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/album/adapter/AlbumRVAdapter.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/album/adapter/AlbumRVAdapter.kt
@@ -12,13 +12,15 @@ class AlbumRVAdapter :
     ListAdapter<Album, AlbumViewHolder>(diffUtil) {
 
     private var callback: (album: Album) -> Unit = {}
+    private var likeCallback: (album: Album) -> Unit = {}
 
-    fun setCallBack(callback: (album: Album) -> Unit) {
+    fun setCallBack(callback: (album: Album) -> Unit, likeCallback: (music: Album) -> Unit) {
         this.callback = callback
+        this.likeCallback = likeCallback
     }
 
     override fun onBindViewHolder(holder: AlbumViewHolder, position: Int) {
-        holder.bind(getItem(position), callback)
+        holder.bind(getItem(position), callback, likeCallback)
     }
 
     override fun onCreateViewHolder(

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/album/viewholder/AlbumViewHolder.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/album/viewholder/AlbumViewHolder.kt
@@ -7,8 +7,15 @@ import com.capstone.artwhale.domain.model.Album
 class AlbumViewHolder(private val binding: ItemAlbumBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(album: Album, callback: (album: Album) -> Unit) {
-        binding.item = album
-        binding.action = callback
+    fun bind(album: Album, callback: (album: Album) -> Unit, likeCallback: (album: Album) -> Unit) {
+        with(binding) {
+            item = album
+            action = callback
+            like = {
+                val isLike = it.isLike
+                item = it.copy(isLike = !isLike)
+                likeCallback(it)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/music/MusicFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/music/MusicFragment.kt
@@ -1,12 +1,14 @@
 package com.capstone.artwhale.presentation.home.music
 
 import android.content.Intent
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.PagerSnapHelper
 import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentMusicBinding
 import com.capstone.artwhale.presentation.common.BaseFragment
+import com.capstone.artwhale.presentation.home.UserViewModel
 import com.capstone.artwhale.presentation.home.music.adapter.MusicChartRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.NewMusicRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.NoticeRVAdapter
@@ -20,6 +22,7 @@ import kotlinx.coroutines.flow.onEach
 class MusicFragment : BaseFragment<FragmentMusicBinding>(FragmentMusicBinding::inflate) {
 
     private val viewModel by viewModels<MusicViewModel>()
+    private val userViewModel by activityViewModels<UserViewModel>()
 
     private lateinit var noticeRVAdapter: NoticeRVAdapter
     private lateinit var musicChartRVAdapter: MusicChartRVAdapter
@@ -48,7 +51,11 @@ class MusicFragment : BaseFragment<FragmentMusicBinding>(FragmentMusicBinding::i
     private fun initRecyclerView() {
         noticeRVAdapter = NoticeRVAdapter()
         musicChartRVAdapter = MusicChartRVAdapter()
-            .apply { setCallBack { playMusic(it) } }
+            .apply {
+                setCallBack(
+                    { playMusic(it) },
+                    { userViewModel.updateMusicLikeState(it) })
+            }
         newMusicRVAdapter = NewMusicRVAdapter()
             .apply { setCallBack { playMusic(it) } }
 

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/music/adapter/MusicChartRVAdapter.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/music/adapter/MusicChartRVAdapter.kt
@@ -12,13 +12,15 @@ class MusicChartRVAdapter :
     ListAdapter<Music, MusicChartViewHolder>(diffUtil) {
 
     private var callback: (music: Music) -> Unit = {}
+    private var likeCallback: (album: Music) -> Unit = {}
 
-    fun setCallBack(callback: (music: Music) -> Unit) {
+    fun setCallBack(callback: (music: Music) -> Unit, likeCallback: (music: Music) -> Unit) {
         this.callback = callback
+        this.likeCallback = likeCallback
     }
 
     override fun onBindViewHolder(holder: MusicChartViewHolder, position: Int) {
-        holder.bind(getItem(position), callback = callback)
+        holder.bind(getItem(position), callback = callback, likeCallback)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MusicChartViewHolder {

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/music/viewholder/MusicChartViewHolder.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/music/viewholder/MusicChartViewHolder.kt
@@ -7,8 +7,15 @@ import com.capstone.artwhale.domain.model.Music
 class MusicChartViewHolder(private val binding: ItemChartMusicBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(music: Music, callback: (music: Music) -> Unit) {
-        binding.item = music
-        binding.action = callback
+    fun bind(music: Music, callback: (music: Music) -> Unit, likeCallback: (music: Music) -> Unit) {
+        with(binding) {
+            item = music
+            action = callback
+            like = {
+                val isLike = it.isLike
+                item = it.copy(isLike = !isLike)
+                likeCallback(it)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/ProfileFragment.kt
@@ -40,8 +40,16 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(FragmentProfileBind
     }
 
     private fun initRecyclerView() {
-        chartRVAdapter = MusicChartRVAdapter().apply { setCallBack { playMusic(it) } }
-        albumRVAdapter = AlbumRVAdapter().apply { setCallBack { registerMusicWithAlbum(it) } }
+        chartRVAdapter = MusicChartRVAdapter().apply {
+            setCallBack(
+                { playMusic(it) },
+                { viewModel.updateMusicLikeState(it) })
+        }
+        albumRVAdapter = AlbumRVAdapter().apply {
+            setCallBack(
+                { registerMusicWithAlbum(it) },
+                { viewModel.updateAlbumLikeState(it) })
+        }
         binding.rvChart.adapter = chartRVAdapter
         binding.rvNewList.adapter = albumRVAdapter
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/ProfileFragment.kt
@@ -40,8 +40,8 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(FragmentProfileBind
     }
 
     private fun initRecyclerView() {
-        chartRVAdapter = MusicChartRVAdapter()
-        albumRVAdapter = AlbumRVAdapter()
+        chartRVAdapter = MusicChartRVAdapter().apply { setCallBack { playMusic(it) } }
+        albumRVAdapter = AlbumRVAdapter().apply { setCallBack { registerMusicWithAlbum(it) } }
         binding.rvChart.adapter = chartRVAdapter
         binding.rvNewList.adapter = albumRVAdapter
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/AlbumListFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/AlbumListFragment.kt
@@ -1,17 +1,18 @@
 package com.capstone.artwhale.presentation.home.profile.common
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.lifecycleScope
-import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentLikeAlbumBinding
-import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
+import com.capstone.artwhale.domain.model.Album
 import com.capstone.artwhale.presentation.home.UserViewModel
+import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
+import com.capstone.artwhale.presentation.register.music.MusicRegisterActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -48,9 +49,15 @@ class AlbumListFragment : Fragment() {
         }.launchIn(this.lifecycleScope)
     }
 
+    private fun registerMusicWithAlbum(album: Album) {
+        val intent = Intent(requireContext(), MusicRegisterActivity::class.java)
+        intent.putExtra("album", album)
+        startActivity(intent)
+    }
+
     private fun initRecyclerView() {
         with(binding) {
-            rvAdapter = AlbumRVAdapter()
+            rvAdapter = AlbumRVAdapter().apply { setCallBack { registerMusicWithAlbum(it) } }
             rvLikeAlbum.adapter = rvAdapter
         }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/AlbumListFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/AlbumListFragment.kt
@@ -57,7 +57,11 @@ class AlbumListFragment : Fragment() {
 
     private fun initRecyclerView() {
         with(binding) {
-            rvAdapter = AlbumRVAdapter().apply { setCallBack { registerMusicWithAlbum(it) } }
+            rvAdapter = AlbumRVAdapter().apply {
+                setCallBack(
+                    { registerMusicWithAlbum(it) },
+                    { viewModel.updateAlbumLikeState(it) })
+            }
             rvLikeAlbum.adapter = rvAdapter
         }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/MusicListFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/MusicListFragment.kt
@@ -7,9 +7,12 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
+import com.capstone.artwhale.R
 import com.capstone.artwhale.databinding.FragmentLikeMusicBinding
+import com.capstone.artwhale.domain.model.Music
 import com.capstone.artwhale.presentation.home.UserViewModel
 import com.capstone.artwhale.presentation.home.music.adapter.MusicChartRVAdapter
+import com.capstone.artwhale.presentation.home.play.MusicPlayerFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -46,9 +49,17 @@ class MusicListFragment : Fragment() {
         }.launchIn(this.lifecycleScope)
     }
 
+    private fun playMusic(music: Music) {
+        val player = MusicPlayerFragment()
+        val bundle = Bundle()
+        bundle.putSerializable("music", music)
+        player.arguments = bundle
+        player.show(childFragmentManager, getString(R.string.fragment_music_player))
+    }
+
     private fun initRecyclerView() {
         with(binding) {
-            rvAdapter = MusicChartRVAdapter()
+            rvAdapter = MusicChartRVAdapter().apply { setCallBack { playMusic(it) } }
             rvLikeMusic.adapter = rvAdapter
         }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/MusicListFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/common/MusicListFragment.kt
@@ -59,7 +59,11 @@ class MusicListFragment : Fragment() {
 
     private fun initRecyclerView() {
         with(binding) {
-            rvAdapter = MusicChartRVAdapter().apply { setCallBack { playMusic(it) } }
+            rvAdapter = MusicChartRVAdapter().apply {
+                setCallBack(
+                    { playMusic(it) },
+                    { viewModel.updateMusicLikeState(it) })
+            }
             rvLikeMusic.adapter = rvAdapter
         }
     }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoEditorFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoEditorFragment.kt
@@ -42,7 +42,7 @@ class UserInfoEditorFragment :
         with(binding) {
             btnSave.setOnClickListener {
                 graphNavigate(R.id.action_profile_save)
-                viewModel.updateProfileInfo()
+                viewModel?.updateProfileInfo()
             }
             ivProfileImg.setOnClickListener { getContent.launch("image/*") }
             btnEditImage.setOnClickListener { getContent.launch("image/*") }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoEditorFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/profile/info/UserInfoEditorFragment.kt
@@ -40,7 +40,10 @@ class UserInfoEditorFragment :
 
     private fun initButton() {
         with(binding) {
-            btnSave.setOnClickListener { graphNavigate(R.id.action_profile_save) }
+            btnSave.setOnClickListener {
+                graphNavigate(R.id.action_profile_save)
+                viewModel.updateProfileInfo()
+            }
             ivProfileImg.setOnClickListener { getContent.launch("image/*") }
             btnEditImage.setOnClickListener { getContent.launch("image/*") }
         }

--- a/app/src/main/java/com/capstone/artwhale/presentation/home/search/SearchFragment.kt
+++ b/app/src/main/java/com/capstone/artwhale/presentation/home/search/SearchFragment.kt
@@ -3,11 +3,13 @@ package com.capstone.artwhale.presentation.home.search
 import android.view.View
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.capstone.artwhale.databinding.FragmentSearchBinding
 import com.capstone.artwhale.domain.model.RecentSearch
 import com.capstone.artwhale.presentation.common.BaseFragment
+import com.capstone.artwhale.presentation.home.UserViewModel
 import com.capstone.artwhale.presentation.home.album.adapter.AlbumRVAdapter
 import com.capstone.artwhale.presentation.home.music.adapter.MusicChartRVAdapter
 import com.capstone.artwhale.presentation.home.search.adapter.RecentSearchRVAdapter
@@ -19,6 +21,7 @@ import kotlinx.coroutines.flow.onEach
 class SearchFragment : BaseFragment<FragmentSearchBinding>(FragmentSearchBinding::inflate) {
 
     private val viewModel by viewModels<SearchViewModel>()
+    private val userViewModel by activityViewModels<UserViewModel>()
 
     private lateinit var albumRVAdapter: AlbumRVAdapter
     private lateinit var musicChartRVAdapter: MusicChartRVAdapter
@@ -65,8 +68,16 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(FragmentSearchBinding
     }
 
     private fun initRecyclerView() {
-        albumRVAdapter = AlbumRVAdapter().apply { setCallBack { registerMusicWithAlbum(it) } }
-        musicChartRVAdapter = MusicChartRVAdapter().apply { setCallBack { playMusic(it) } }
+        musicChartRVAdapter = MusicChartRVAdapter().apply {
+            setCallBack(
+                { playMusic(it) },
+                { userViewModel.updateMusicLikeState(it) })
+        }
+        albumRVAdapter = AlbumRVAdapter().apply {
+            setCallBack(
+                { registerMusicWithAlbum(it) },
+                { userViewModel.updateAlbumLikeState(it) })
+        }
         recentSearchRVAdapter = RecentSearchRVAdapter().apply {
             listener = object : RecentSearchRVAdapter.ClickListener {
                 override fun onClickItem(item: RecentSearch) {

--- a/app/src/main/java/com/capstone/artwhale/util/FileUtil.kt
+++ b/app/src/main/java/com/capstone/artwhale/util/FileUtil.kt
@@ -1,0 +1,250 @@
+package com.capstone.artwhale.util
+
+import android.annotation.SuppressLint
+import android.content.ContentResolver
+import android.content.ContentUris
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.DocumentsContract
+import android.provider.MediaStore
+import android.text.TextUtils
+import android.util.Log
+import androidx.annotation.RequiresApi
+import org.apache.commons.io.IOUtils
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+
+object FileUtil {
+    /* Get uri related content real local file path. */
+    fun getPath(ctx: Context, uri: Uri): String? {
+        val ret: String?
+        ret = try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                // Android OS above sdk version 19.
+                getUriRealPathAboveKitkat(ctx, uri)
+            } else {
+                // Android OS below sdk version 19
+                getRealPath(ctx.contentResolver, uri, null)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Log.d("DREG", "FilePath Catch: $e")
+            getFilePathFromURI(ctx, uri)
+        }
+        return ret
+    }
+
+    private fun getFilePathFromURI(context: Context, contentUri: Uri): String? {
+        //copy file and send new file path
+        val fileName = getFileName(contentUri)
+        if (!TextUtils.isEmpty(fileName)) {
+            val TEMP_DIR_PATH = Environment.getExternalStorageDirectory().path
+            val copyFile = File(TEMP_DIR_PATH + File.separator + fileName)
+            Log.d("DREG", "FilePath copyFile: $copyFile")
+            copy(context, contentUri, copyFile)
+            return copyFile.absolutePath
+        }
+        return null
+    }
+
+    fun getFileName(uri: Uri?): String? {
+        if (uri == null) return null
+        var fileName: String? = null
+        val path = uri.path
+        val cut = path!!.lastIndexOf('/')
+        if (cut != -1) {
+            fileName = path.substring(cut + 1)
+        }
+        return fileName
+    }
+
+    fun copy(context: Context, srcUri: Uri?, dstFile: File?) {
+        try {
+            val inputStream = context.contentResolver.openInputStream(srcUri!!) ?: return
+            val outputStream: OutputStream = FileOutputStream(dstFile)
+            IOUtils.copy(inputStream, outputStream) // org.apache.commons.io
+            inputStream.close()
+            outputStream.close()
+        } catch (e: Exception) { // IOException
+            e.printStackTrace()
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    private fun getUriRealPathAboveKitkat(ctx: Context?, uri: Uri?): String? {
+        var ret: String? = ""
+        if (ctx != null && uri != null) {
+            if (isContentUri(uri)) {
+                ret = if (isGooglePhotoDoc(uri.authority)) {
+                    uri.lastPathSegment
+                } else {
+                    getRealPath(ctx.contentResolver, uri, null)
+                }
+            } else if (isFileUri(uri)) {
+                ret = uri.path
+            } else if (isDocumentUri(ctx, uri)) {
+
+                // Get uri related document id.
+                val documentId = DocumentsContract.getDocumentId(uri)
+
+                // Get uri authority.
+                val uriAuthority = uri.authority
+                if (isMediaDoc(uriAuthority)) {
+                    val idArr = documentId.split(":").toTypedArray()
+                    if (idArr.size == 2) {
+                        // First item is document type.
+                        val docType = idArr[0]
+
+                        // Second item is document real id.
+                        val realDocId = idArr[1]
+
+                        // Get content uri by document type.
+                        var mediaContentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+                        if ("image" == docType) {
+                            mediaContentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+                        } else if ("video" == docType) {
+                            mediaContentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+                        } else if ("audio" == docType) {
+                            mediaContentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+                        }
+
+                        // Get where clause with real document id.
+                        val whereClause = MediaStore.Images.Media._ID + " = " + realDocId
+                        ret = getRealPath(ctx.contentResolver, mediaContentUri, whereClause)
+                    }
+                } else if (isDownloadDoc(uriAuthority)) {
+                    // Build download uri.
+                    val downloadUri = Uri.parse("content://downloads/public_downloads")
+
+                    // Append download document id at uri end.
+                    val downloadUriAppendId =
+                        ContentUris.withAppendedId(downloadUri, java.lang.Long.valueOf(documentId))
+                    ret = getRealPath(ctx.contentResolver, downloadUriAppendId, null)
+                } else if (isExternalStoreDoc(uriAuthority)) {
+                    val idArr = documentId.split(":").toTypedArray()
+                    if (idArr.size == 2) {
+                        val type = idArr[0]
+                        val realDocId = idArr[1]
+                        if ("primary".equals(type, ignoreCase = true)) {
+                            ret = Environment.getExternalStorageDirectory()
+                                .toString() + "/" + realDocId
+                        }
+                    }
+                }
+            }
+        }
+        return ret
+    }
+
+    /* Check whether this uri represent a document or not. */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    private fun isDocumentUri(ctx: Context?, uri: Uri?): Boolean {
+        var ret = false
+        if (ctx != null && uri != null) {
+            ret = DocumentsContract.isDocumentUri(ctx, uri)
+        }
+        return ret
+    }
+
+    /* Check whether this uri is a content uri or not.
+     *  content uri like content://media/external/images/media/1302716
+     *  */
+    private fun isContentUri(uri: Uri?): Boolean {
+        var ret = false
+        if (uri != null) {
+            val uriSchema = uri.scheme
+            if ("content".equals(uriSchema, ignoreCase = true)) {
+                ret = true
+            }
+        }
+        return ret
+    }
+
+    /* Check whether this uri is a file uri or not.
+     *  file uri like file:///storage/41B7-12F1/DCIM/Camera/IMG_20180211_095139.jpg
+     * */
+    private fun isFileUri(uri: Uri?): Boolean {
+        var ret = false
+        if (uri != null) {
+            val uriSchema = uri.scheme
+            if ("file".equals(uriSchema, ignoreCase = true)) {
+                ret = true
+            }
+        }
+        return ret
+    }
+
+    /* Check whether this document is provided by ExternalStorageProvider. */
+    private fun isExternalStoreDoc(uriAuthority: String?): Boolean {
+        var ret = false
+        if ("com.android.externalstorage.documents" == uriAuthority) {
+            ret = true
+        }
+        return ret
+    }
+
+    /* Check whether this document is provided by DownloadsProvider. */
+    private fun isDownloadDoc(uriAuthority: String?): Boolean {
+        var ret = false
+        if ("com.android.providers.downloads.documents" == uriAuthority) {
+            ret = true
+        }
+        return ret
+    }
+
+    /* Check whether this document is provided by MediaProvider. */
+    private fun isMediaDoc(uriAuthority: String?): Boolean {
+        var ret = false
+        if ("com.android.providers.media.documents" == uriAuthority) {
+            ret = true
+        }
+        return ret
+    }
+
+    /* Check whether this document is provided by google photos. */
+    private fun isGooglePhotoDoc(uriAuthority: String?): Boolean {
+        var ret = false
+        if ("com.google.android.apps.photos.content" == uriAuthority) {
+            ret = true
+        }
+        return ret
+    }
+
+    /* Return uri represented document file real local path.*/
+    @SuppressLint("Recycle")
+    private fun getRealPath(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        whereClause: String?
+    ): String {
+        var ret = ""
+
+        // Query the uri with condition.
+        val cursor = contentResolver.query(uri, null, whereClause, null, null)
+        if (cursor != null) {
+            val moveToFirst = cursor.moveToFirst()
+            if (moveToFirst) {
+
+                // Get columns name by uri type.
+                var columnName = MediaStore.Images.Media.DATA
+                if (uri === MediaStore.Images.Media.EXTERNAL_CONTENT_URI) {
+                    columnName = MediaStore.Images.Media.DATA
+                } else if (uri === MediaStore.Audio.Media.EXTERNAL_CONTENT_URI) {
+                    columnName = MediaStore.Audio.Media.DATA
+                } else if (uri === MediaStore.Video.Media.EXTERNAL_CONTENT_URI) {
+                    columnName = MediaStore.Video.Media.DATA
+                }
+
+                // Get column index.
+                val columnIndex = cursor.getColumnIndex(columnName)
+
+                // Get column value which is the uri related file local path.
+                ret = cursor.getString(columnIndex)
+            }
+        }
+        return ret
+    }
+}

--- a/app/src/main/java/com/capstone/artwhale/util/LocalPathUtil.kt
+++ b/app/src/main/java/com/capstone/artwhale/util/LocalPathUtil.kt
@@ -1,0 +1,17 @@
+package com.capstone.artwhale.util
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.Uri
+import javax.inject.Inject
+
+class LocalPathUtil @Inject constructor(
+    private val context: Context
+) {
+    fun getRealPathFromUriString(contentUri: String): String? =
+        getRealPathFromUri(Uri.parse(contentUri))
+
+    @SuppressLint("Recycle")
+    fun getRealPathFromUri(uri: Uri): String? =
+        FileUtil.getPath(context, uri)
+}

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -8,6 +8,8 @@
         <variable
             name="viewModel"
             type="com.capstone.artwhale.presentation.home.UserViewModel" />
+
+        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -35,6 +37,7 @@
                     android:layout_marginStart="15dp"
                     android:layout_marginTop="40dp"
                     android:text="@string/like_album"
+                    android:visibility="@{viewModel.likeAlbum.isEmpty() ? View.GONE : View.VISIBLE}"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
@@ -48,6 +51,7 @@
                     android:focusable="true"
                     android:onClick="@{(view) -> viewModel.onClickButton(view)}"
                     android:text="@string/all_list"
+                    android:visibility="@{viewModel.likeAlbum.isEmpty() ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_new_list"
                     app:layout_constraintEnd_toEndOf="parent" />
 
@@ -58,6 +62,7 @@
                     android:layout_marginTop="13dp"
                     android:orientation="vertical"
                     android:padding="5dp"
+                    android:visibility="@{viewModel.likeAlbum.isEmpty() ? View.GONE : View.VISIBLE}"
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -74,6 +79,7 @@
                     android:layout_marginStart="15dp"
                     android:layout_marginTop="22dp"
                     android:text="@string/like_music"
+                    android:visibility="@{viewModel.likeMusic.isEmpty() ? View.GONE : View.VISIBLE}"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/rv_new_list" />
 
@@ -87,6 +93,7 @@
                     android:focusable="true"
                     android:onClick="@{(view) -> viewModel.onClickButton(view)}"
                     android:text="@string/all_list"
+                    android:visibility="@{viewModel.likeMusic.isEmpty() ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_chart"
                     app:layout_constraintEnd_toEndOf="parent" />
 
@@ -96,6 +103,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="13dp"
                     android:orientation="vertical"
+                    android:visibility="@{viewModel.likeMusic.isEmpty() ? View.GONE : View.VISIBLE}"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -104,6 +112,17 @@
                     tools:listitem="@layout/item_chart_music" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/notice_empty"
+            android:textAppearance="@style/description.veryLarge"
+            android:visibility="@{viewModel.likeMusic.isEmpty() &amp; viewModel.likeAlbum.isEmpty()? View.VISIBLE : View.GONE}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/fcv_profile" />
 
         <ImageView
             android:id="@+id/iv_blur"

--- a/app/src/main/res/layout/item_album.xml
+++ b/app/src/main/res/layout/item_album.xml
@@ -18,6 +18,10 @@
         <variable
             name="action"
             type="Function1&lt;Album, Unit>" />
+
+        <variable
+            name="like"
+            type="Function1&lt;Album, Unit>" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -49,6 +53,7 @@
             android:layout_margin="10dp"
             android:clickable="true"
             android:focusable="true"
+            android:onClick="@{() -> like.invoke(item)}"
             android:src="@drawable/ic_like_selector"
             app:layout_constraintEnd_toEndOf="@id/iv_album_thumbnail"
             app:layout_constraintTop_toTopOf="@id/iv_album_thumbnail" />

--- a/app/src/main/res/layout/item_chart_music.xml
+++ b/app/src/main/res/layout/item_chart_music.xml
@@ -18,6 +18,10 @@
         <variable
             name="action"
             type="Function1&lt;Music, Unit>" />
+
+        <variable
+            name="like"
+            type="Function1&lt;Music, Unit>" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -83,6 +87,7 @@
             android:layout_height="18dp"
             android:clickable="true"
             android:focusable="true"
+            android:onClick="@{() -> like.invoke(item)}"
             android:src="@drawable/ic_like_selector"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="input_title">제목을 입력하세요</string>
     <string name="register">Register</string>
     <string name="input_lyrics">가사를 입력하세요</string>
+    <string name="notice_empty">비어있습니다!</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
         blur_version = '4.0.1'
 
         room_version = "2.4.3"
+        common_version = "2.4"
     }
 }
 plugins {


### PR DESCRIPTION
### ❗️ 이슈
- close #56 

### 📝 구현한 내용
- 아키텍처 설계 및 적용
- 파일 유틸 생성
  - 실제 파일 경로를 받아올 수 있도록 유틸을 만들어 관리한다.

### ❓ 고민한 내용
- 파일 경로 받아오기
  - AOS 11부터 이전에 사용해왔던 파일 경로 받아오기 (URI에서 파일을 직접 건드리는 것)가 잘 먹히지 않는다.
  - [링크](https://www.semicolonworld.com/question/45962/how-to-get-the-full-file-path-from-uri)에서 보여지는 방법으로는 아직 되기에 이를 적용한다.
  - 하지만, 정확한 방법은 아니니 다시한번 체크할 릴요가 있다.
- 갤러리에서 이미지 가져오기
  - 파일 탐색기에서 이미지를 받아오면 경로가 제대로 만들어지지 않는다.
  - 갤러리로 직접 들어가 이미지를 불러와야 되는데 이를 수정할 필요가 있다.